### PR TITLE
寿司表示の修正#53

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -148,8 +148,8 @@ body {
 }
 
 .sushi-img {
-  max-width: 110px;
-  max-height: 80px;
+  max-width: 200px;
+  max-height: 110px;
 }
 
 .sushi-count {
@@ -177,3 +177,4 @@ body {
   color: white;
   border-radius: 6px;
 }
+

--- a/app/controllers/sushi_items_controller.rb
+++ b/app/controllers/sushi_items_controller.rb
@@ -16,7 +16,7 @@ class SushiItemsController < ApplicationController
   end
 
   def index
-    @sushi_items = SushiItem.includes(:sushi_item_counters, :category)
+    @sushi_items = SushiItem.includes(:sushi_item_counters, :category).where("created_by_user_id = ? OR created_by_user_id IS NULL", current_user.id)
 
     if user_signed_in?
       @counter = current_user.counters.order(created_at: :desc).first_or_create!(eaten_at: Time.current)

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -7,3 +7,24 @@ window.Rails = Rails
 
 import "./controllers"
 import * as bootstrap from "bootstrap"
+
+
+document.addEventListener("turbo:render", () => {
+  console.log("🔥 turbo:load event fired"); // ← これが出れば動いてる！
+
+  const flashMessages = document.querySelectorAll(".flash-message");
+
+  flashMessages.forEach((msg) => {
+    console.log("🙌 flash message found:", msg.innerText); // ← これも表示されるか？
+    
+    setTimeout(() => {
+      msg.style.transition = "opacity 0.5s ease-out";
+      msg.style.opacity = "0";
+
+      // 完全に消す（DOMから削除）場合は以下も
+      setTimeout(() => {
+        msg.remove();
+      }, 500);
+    }, 3000); // 3秒後にフェード開始
+  });
+});

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -3,10 +3,8 @@
     <div class="card-body">
       <h2 class="card-title text-center mb-4">ログイン</h2>
 
-      <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "needs-validation" }) do |f| %>
-        <% if flash[:alert] %>
-          <div class="alert alert-danger"><%= flash[:alert] %></div>
-        <% end %>
+      <%= form_with model: resource, url: user_session_path, html: { class: "needs-validation" } do |f| %>
+        <%= render "devise/shared/error_messages", resource: resource %>
 
         <div class="mb-3">
           <%= f.label :email, class: "form-label mb-1" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,12 +12,8 @@
   </head>
 
   <body>
-    <% flash.each do |key, message| %>
-      <div class="alert alert-<%= key == "notice" ? "success" : "danger" %>">
-        <%= message %>
-      </div>
-    <% end %>
     <%= render 'shared/header' %>
+    <%= render 'shared/flash_messages' %>
     <div class="main-container">
       <%= yield %>
       <%= render 'shared/footer' %>

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -1,0 +1,7 @@
+<div class="flash-overlay position-fixed top-0 start-50 translate-middle-x mt-1 z-1050" style="min-width: 300px;">
+  <% flash.each do |key, message| %>
+    <div class="alert alert-<%= key == "notice" ? "success" : "danger" %> flash-message">
+      <%= message %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -57,7 +57,7 @@
   </div>
 </div>
 
-<% if !user_signed_in? && request.path != "/users/sign_in" && request.path != "/users/sign_up" %>
+<% if !user_signed_in? && request.path != "/users/sign_in" && request.path != "/users/sign_up" && request.path != user_registration_path %>
   <div class="d-flex justify-content-center mt-4 mb-4">
     <div class="border-navy rounded p-4 text-center bg-white" style="max-width: 500px;">
       <h5 class="smahosize fw-bold mb-3">ゲストユーザーで利用中です。</h5>

--- a/app/views/sushi_items/index.html.erb
+++ b/app/views/sushi_items/index.html.erb
@@ -14,7 +14,7 @@
       <p class="sushi-name"><%= sushi.name %></p>
       <% if sushi.created_by_user_id == current_user.id %>
         <%= link_to "編集", edit_sushi_item_path(sushi) %>
-        <%= button_to "削除", sushi_item_path(sushi), method: :delete, data: { turbo: false,confirm: "本当に削除しますか？" }, class: "btn btn-danger" %>
+        <%= button_to "削除", sushi_item_path(sushi), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "btn btn-danger" %>
       <% else %>
         <p>（この寿司は編集・削除できません）</p>
       <% end %>


### PR DESCRIPTION
## 概要
寿司一覧画面に初期データの寿司とログインユーザーが作成した寿司のみが表示されるように修正。

## 実施内容
sushi_items_controllerでcreate_by_userの値がNULLまたは、current_user.idのアイテムだけを取得するように修正。