### PR TITLE
カテゴリメニュー作成#54

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -21,7 +21,7 @@ body {
 }
 
 .main-container {
-  padding: 1rem; // 外側に余白を追加
+  padding: 0 0.5rem 1rem 0.5rem; /* 上 0、右下左 1rem */ // 外側に余白を追加
 }
 
 .bg-navy {
@@ -47,6 +47,16 @@ body {
 
   &:hover {
     background-color: #2549A6;  // 少し明るいネイビー
+    color: #ffffff;
+  }
+}
+
+.btn-outline-navy {
+  background-color: #ffffff;
+  color: #0A2D88;
+  
+  &:hover {
+    background-color: #f8f9fa;  // 少し明るいネイビー
     color: #ffffff;
   }
 }
@@ -130,7 +140,16 @@ body {
 
 .sushi-grid {
   display: grid;
+  @media (max-width: 576px) {
   grid-template-columns: repeat(2, 1fr);
+  }
+    @media (min-width: 900px) {
+  grid-template-columns: repeat(4, 1fr);
+  }
+    @media (min-width: 1200px) {
+  grid-template-columns: repeat(5, 1fr);
+  }
+  grid-template-columns: repeat(3, 1fr);
   gap: 12px;
   padding: 10px;
 }
@@ -149,7 +168,7 @@ body {
 
 .sushi-img {
   max-width: 200px;
-  max-height: 110px;
+  max-height: 80px;
 }
 
 .sushi-count {
@@ -173,8 +192,39 @@ body {
   height: 40px;
   font-size: 20px;
   font-weight: bold;
-  background-color: navy;
+  background-color: #0A2D88;
   color: white;
   border-radius: 6px;
 }
 
+.spsize-category{
+  font-size: 1.2rem; //.常サイズ
+
+  @media (max-width: 576px) {
+    font-size: 0.75rem; // スマホサイズ
+  }
+}
+
+.category-nav {
+  position: sticky;
+  top: 0;
+  z-index: 1000; /* 必要に応じて上に表示されるよう調整 */
+  background-color: #f8f9fa; /* 背景色を指定しないと、下の要素が透けることがある */
+  padding: 0.4rem 0;
+}
+
+.btn-nav {
+  position: fixed;
+  bottom: 70px;
+  right: 0.5rem;
+  z-index: 1000;
+}
+
+.btn-shadow {
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.233); /* 水平, 垂直, ぼかし, 色 */
+}
+
+
+.mb-6 {
+  margin-bottom: 6rem; /* 例えば 64px */
+}

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -1,7 +1,9 @@
 <div class="flash-overlay position-fixed top-0 start-50 translate-middle-x mt-1 z-1050" style="min-width: 300px;">
   <% flash.each do |key, message| %>
     <div class="alert alert-<%= key == "notice" ? "success" : "danger" %> flash-message">
-      <%= message %>
+      <div class="text-center">
+        <%= message %>
+      </div>
     </div>
   <% end %>
 </div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,3 +1,4 @@
+
 <ul class="bottom-nav list-unstyled d-flex justify-content-around align-items-center m-0 p-0 fixed-bottom">
   <li class="nav-item text-center flex-fill">
     <%= link_to root_path, class: "nav-link text-navy" do %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -32,7 +32,7 @@
         <%= link_to 'ホーム', root_path, class: 'nav-link text-navy' %>
       </li>
       <li class="nav-item mb-2">
-        <%= link_to 'カウンター', "#", class: 'nav-link text-navy' %>
+        <%= link_to 'カウンター', sushi_items_path, class: 'nav-link text-navy' %>
       </li>
       <li class="nav-item mb-2">
         <%= link_to 'カウント履歴', "#", class: 'nav-link text-navy' %>

--- a/app/views/sushi_items/_sushi_item.html.erb
+++ b/app/views/sushi_items/_sushi_item.html.erb
@@ -1,0 +1,20 @@
+<div class="sushi-card" id="sushi_<%= sushi_item.id %>">
+  <div class="count-display">
+    <%= image_tag sushi_item.image, class: "sushi-img" if sushi_item.image.present?%>
+    <div class="sushi-count" id="count_<%= sushi_item.id %>">
+      <%= sushi_item.sushi_item_counters.find_by(counter_id: @counter.id)&.count || 0 %>
+    </div>
+  </div>
+  <div class="count-buttons">
+    <%= button_to "-", update_count_sushi_item_path(sushi_item, direction: "decrement"), method: :patch, form: { data: { turbo_stream: true }}, class: "count-btn minus" %>
+    <%= button_to "+", update_count_sushi_item_path(sushi_item, direction: "increment"), method: :patch, form: { data: { turbo_stream: true }}, class: "count-btn plus" %>
+  </div>
+  <p class="sushi-name"><%= sushi_item.name %></p>
+  <% if sushi_item.created_by_user_id == current_user.id %>
+    <%= link_to "編集", edit_sushi_item_path(sushi_item) %>
+    <%= button_to "削除", sushi_item_path(sushi_item), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "btn btn-danger" %>
+  <% elsif sushi_item.created_by_user_id.nil? %>
+    <%= link_to "編集", edit_sushi_item_path(sushi_item) %>
+  <% end %>
+</div>
+

--- a/app/views/sushi_items/edit.html.erb
+++ b/app/views/sushi_items/edit.html.erb
@@ -1,26 +1,46 @@
 <div class="container my-4" style="max-width: 500px;">
   <%= form_with model: @sushi_item, local: true, html: { class: "p-4 border rounded bg-white" } do |f| %>
-    <div class="mb-3">
-      <%= f.label :name, class: "form-labe mb-1" %>
-      <%= f.text_field :name, class: "form-control" %>
-    </div>
+    <% if @sushi_item.created_by_user_id == current_user.id %>
+      <div class="mb-3">
+        <%= f.label :name, class: "form-labe mb-1" %>
+        <%= f.text_field :name, class: "form-control" %>
+      </div>
+    
+      <div class="mb-3">
+        <%= f.label :category_id, "カテゴリー", class: "form-label mb-1" %>
+        <%= f.collection_select :category_id, @categories, :id, :name, { prompt: "選択してください" }, class: "form-select" %>
+      </div>
+    
+      <div class="mb-3">
+        <%= f.label :image, class: "form-label mb-1" %>
+        <%= f.file_field :image, class: "form-control" %>
+    
+        <% if @sushi_item.image.attached? %>
+          <div class="mt-3">
+            <%= image_tag @sushi_item.image.variant(resize_to_limit: [200, 200]), class: "img-thumbnail mb-3" %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+
+    <% if @sushi_item.created_by_user_id.nil? %>
+      <div class="mb-3">
+        <%= f.label :image, class: "form-label mb-1" %>
+        <%= f.file_field :image, class: "form-control" %>
   
-    <div class="mb-3">
-      <%= f.label :category_id, "カテゴリー", class: "form-label mb-1" %>
-      <%= f.collection_select :category_id, @categories, :id, :name, { prompt: "選択してください" }, class: "form-select" %>
-    </div>
-  
-    <div class="mb-3">
-      <%= f.label :image, class: "form-label mb-1" %>
-      <%= f.file_field :image, class: "form-control" %>
-  
-      <% if @sushi_item.image.attached? %>
-        <div class="mt-3">
-          <%= image_tag @sushi_item.image.variant(resize_to_limit: [200, 200]), class: "img-thumbnail mb-3" %>
-        </div>
-      <% end %>
-    </div>
-  
+        <% if @sushi_item.image.attached? %>
+          <div class="mt-3">
+            <%= image_tag @sushi_item.image.variant(resize_to_limit: [200, 200]), class: "img-thumbnail mb-3" %>
+          </div>
+        <% end %>
+      </div>
+
+      <div class="form-check">
+        <%= f.check_box :reset_to_default_image, { class: "form-check-input" } %>
+        <%= f.label :reset_to_default_image, "初期画像に戻す", class: "form-check-label" %>
+      </div>
+    <% end %>
+
     <div class="d-grid mt-4">
       <%= f.submit "更新", class: "btn btn-navy" %>
     </div>

--- a/app/views/sushi_items/index.html.erb
+++ b/app/views/sushi_items/index.html.erb
@@ -1,26 +1,15 @@
-<div class="sushi-grid">
-  <% @sushi_items.each do |sushi| %>
-    <div class="sushi-card" id="sushi_<%= sushi.id %>">
-      <div class="count-display">
-        <%= image_tag sushi.image, class: "sushi-img" if sushi.image.present?%>
-        <div class="sushi-count" id="count_<%= sushi.id %>">
-          <%= sushi.sushi_item_counters.find_by(counter_id: @counter.id)&.count || 0 %>
-        </div>
-      </div>
-      <div class="count-buttons">
-        <%= button_to "-", update_count_sushi_item_path(sushi, direction: "decrement"), method: :patch, form: { data: { turbo_stream: true }}, class: "count-btn minus" %>
-        <%= button_to "+", update_count_sushi_item_path(sushi, direction: "increment"), method: :patch, form: { data: { turbo_stream: true }}, class: "count-btn plus" %>
-      </div>
-      <p class="sushi-name"><%= sushi.name %></p>
-      <% if sushi.created_by_user_id == current_user.id %>
-        <%= link_to "編集", edit_sushi_item_path(sushi) %>
-        <%= button_to "削除", sushi_item_path(sushi), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "btn btn-danger" %>
-      <% else %>
-        <p>（この寿司は編集・削除できません）</p>
-      <% end %>
-    </div>
+<div class="text-center category-nav">
+  <% @categories.each do |category| %>
+    <% is_selected = @selected_category.id == category.id %>
+    <%= link_to category.name, sushi_items_path(category_id: category.id), 
+        class: "btn #{is_selected ? 'btn-navy' : 'text-navy'} fw-bold spsize-category" %>
   <% end %>
 </div>
-<div class="text-center">
-  <%= link_to '寿司追加', new_sushi_item_path, class: 'btn btn-navy fw-bold' %>
+
+<div class="sushi-grid mb-6">
+  <%= render @sushi_items %>
+</div>
+
+<div class="btn-nav">
+  <%= link_to '寿司追加', new_sushi_item_path, class: 'btn btn-navy fw-bold btn-shadow' %>
 </div>

--- a/db/seed_images.rb
+++ b/db/seed_images.rb
@@ -5,6 +5,11 @@ def attach_image(name:, filename:)
   sushi = SushiItem.find_by(name: name, created_by_user_id: nil)
   return puts "見つかりません: #{name}" unless sushi
 
+  if sushi.image.attached?
+    puts "スキップ（既に画像あり）: #{name}"
+    return
+  end
+
   image_path = Rails.root.join("app/assets/images/seeds/#{filename}")
   unless File.exist?(image_path)
     puts "画像ファイルが存在しません: #{filename}"


### PR DESCRIPTION
## 概要
カテゴリーメニュー作成

## 実施内容
- カウント画面にカテゴリーメニューを作成
- カテゴリごとに寿司を表示できる
- スクロールしても上に固定
- 寿司追加ボタンは右下に固定