### PR TITLE
カウントリセット機能実装#49

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -208,7 +208,7 @@ body {
 .category-nav {
   position: sticky;
   top: 0;
-  z-index: 1000; /* 必要に応じて上に表示されるよう調整 */
+  z-index: 500; /* 必要に応じて上に表示されるよう調整 */
   background-color: #f8f9fa; /* 背景色を指定しないと、下の要素が透けることがある */
   padding: 0.4rem 0;
 }
@@ -217,6 +217,13 @@ body {
   position: fixed;
   bottom: 70px;
   right: 0.5rem;
+  z-index: 1000;
+}
+
+.btn-nav2 {
+  position: fixed;
+  bottom: 70px;
+  left: 0.5rem;
   z-index: 1000;
 }
 
@@ -256,3 +263,4 @@ body {
 .d-none {
   display: none !important;
 }
+

--- a/app/controllers/counters_controller.rb
+++ b/app/controllers/counters_controller.rb
@@ -1,4 +1,8 @@
 class CountersController < ApplicationController
-  def index
+  def reset_items
+    counter = current_user.counters.find(params[:id])
+    counter.sushi_item_counters.destroy_all
+
+    redirect_back fallback_location: sushi_items_path, notice: "カウントをリセットしました"
   end
 end

--- a/app/controllers/sushi_items_controller.rb
+++ b/app/controllers/sushi_items_controller.rb
@@ -138,16 +138,10 @@ class SushiItemsController < ApplicationController
     end
   end
 
-  def remove_image
-    @sushi_item = current_user.sushi_items.find(params[:id])
-    @sushi_item.image.purge
-    redirect_to edit_sushi_item_path(@sushi_item)
-  end
-
   private
 
   def sushi_item_params
-    params.require(:sushi_item).permit(:name, :image, :category_id, :created_by_user)
+    params.require(:sushi_item).permit(:name, :image, :category_id, :created_by_user, :remove_image)
   end
 
   def selected_category

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -9,14 +9,14 @@ import "./controllers"
 import * as bootstrap from "bootstrap"
 
 
-document.addEventListener("turbo:render", () => {
+document.addEventListener("turbo:load", () => {
   console.log("🔥 turbo:load event fired"); // ← これが出れば動いてる！
 
   const flashMessages = document.querySelectorAll(".flash-message");
 
   flashMessages.forEach((msg) => {
     console.log("🙌 flash message found:", msg.innerText); // ← これも表示されるか？
-    
+
     setTimeout(() => {
       msg.style.transition = "opacity 0.5s ease-out";
       msg.style.opacity = "0";

--- a/app/javascript/controllers/flash_controller.js
+++ b/app/javascript/controllers/flash_controller.js
@@ -1,0 +1,16 @@
+// app/javascript/controllers/flash_controller.js
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    console.log("🔥 turbo:load flash"); // ← これが出れば動いてる！
+    setTimeout(() => {
+      this.element.style.transition = "opacity 0.5s ease-out"
+      this.element.style.opacity = "0"
+
+      setTimeout(() => {
+        this.element.remove()
+      }, 500)
+    }, 3000) // 3秒後にフェードアウト
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,7 +6,11 @@ import { application } from "./application"
 import ModalController from "./modal_controller"
 import ModalCloseHookController from "./modal_close_hook_controller"
 import HelloController from "./hello_controller"
+import FlashController from "./flash_controller"
 
 application.register("hello", HelloController)
 application.register("modal", ModalController)
 application.register("modal-close-hook", ModalCloseHookController)
+
+Stimulus.register("flash", FlashController)
+

--- a/app/models/sushi_item.rb
+++ b/app/models/sushi_item.rb
@@ -5,9 +5,11 @@ class SushiItem < ApplicationRecord
   has_many :sushi_item_counters, dependent: :destroy
   has_one_attached :image
   attr_accessor :reset_to_default_image
+  attr_accessor :remove_image
 
   before_destroy :prevent_system_item_deletion
   before_update :prevent_system_item_editing
+  before_save :purge_image_if_requested
 
   private
 
@@ -26,5 +28,9 @@ class SushiItem < ApplicationRecord
       errors.add(:base, "初期データの寿司は編集できません")
       throw(:abort)
     end
+  end
+
+  def purge_image_if_requested
+    image.purge if remove_image == "1"
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,7 @@
     <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
-    <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+    <%= javascript_include_tag "application", type: "module", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css", rel: "stylesheet" %>
   </head>
 

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -1,6 +1,8 @@
-<div class="flash-overlay position-fixed top-0 start-50 translate-middle-x mt-1 z-1050" style="min-width: 300px;">
+<div id="flash_messages" 
+    class="flash-overlay position-fixed top-0 start-50 translate-middle-x mt-1 z-1050" 
+    style="min-width: 300px; z-index: 9999;">
   <% flash.each do |key, message| %>
-    <div class="alert alert-<%= key == "notice" ? "success" : "danger" %> flash-message">
+    <div class="alert alert-<%= key == "notice" ? "success" : "danger" %> flash-message" data-controller="flash">
       <div class="text-center">
         <%= message %>
       </div>

--- a/app/views/sushi_items/_edit_form.html.erb
+++ b/app/views/sushi_items/_edit_form.html.erb
@@ -21,6 +21,10 @@
           <div class="mt-3">
             <%= image_tag sushi.image.variant(resize_to_limit: [200, 200]), class: "img-thumbnail mb-3" %>
           </div>
+          <div class="form-check">
+            <%= f.check_box :remove_image, { class: "form-check-input" } %>
+            <%= f.label :remove_image, "画像を削除", class: "form-check-label" %>
+          </div>
         <% end %>
       </div>
     <% end %>
@@ -48,11 +52,3 @@
     </div>
   <% end %>
 </div>
-
-<% if sushi.image.attached? && sushi.created_by_user_id == current_user.id %>
-  <div class="mt-3 text-center">
-    <%= button_to "画像を削除", remove_image_sushi_item_path(sushi),
-          method: :delete,
-          class: "btn btn-danger" %>
-  </div>
-<% end %>

--- a/app/views/sushi_items/create.turbo_stream.erb
+++ b/app/views/sushi_items/create.turbo_stream.erb
@@ -34,5 +34,9 @@
 
 
 <%= turbo_stream.append "flash_messages" do %>
-  <div class="flash-overlay alert alert-success">更新しました</div>
+  <div class="alert alert-success flash-message" data-controller="flash">
+    <div class="text-center">
+      追加しました
+    </div>
+  </div>
 <% end %>

--- a/app/views/sushi_items/destroy.turbo_stream.erb
+++ b/app/views/sushi_items/destroy.turbo_stream.erb
@@ -1,5 +1,9 @@
 <%= turbo_stream.remove "sushi_item_#{@sushi_item.id}" %>
 
 <%= turbo_stream.append "flash_messages" do %>
-  <div class="flash-overlay alert alert-success">削除しました</div>
+  <div class="alert alert-success flash-message" data-controller="flash">
+    <div class="text-center">
+      削除しました
+    </div>
+  </div>
 <% end %>

--- a/app/views/sushi_items/index.html.erb
+++ b/app/views/sushi_items/index.html.erb
@@ -9,6 +9,13 @@
   </div>
 </turbo-frame>
 
+<div class="btn-nav2">
+  <%= button_to "寿司カウントをリセット", reset_items_counter_path(@counter),
+            method: :delete,
+            data: { confirm: "本当にこのカウントをリセットしますか？" },
+            class: "btn btn-warning btn-shadow" %>
+</div>
+
 <!-- モーダル１つにまとめる -->
 <div data-controller="modal"
     data-action="turbo:frame-load->modal#show click@window->modal#outsideClick"

--- a/app/views/sushi_items/update.turbo_stream.erb
+++ b/app/views/sushi_items/update.turbo_stream.erb
@@ -29,5 +29,9 @@
 
 
 <%= turbo_stream.append "flash_messages" do %>
-  <div class="flash-overlay alert alert-success">更新しました</div>
+  <div class="alert alert-success flash-message" data-controller="flash">
+    <div class="text-center">
+      更新しました
+    </div>
+  </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,8 +7,11 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :counters, only: %i[index] 
-    
+  resources :counters do
+    member do
+      delete :reset_items
+    end
+  end
 
   devise_for :users
   devise_scope :users do


### PR DESCRIPTION
## 概要
カウントリセット機能を追加

## 実施内容
- カウント画面でリセットボタンを押すとカウントがすべて０になる
- counterに紐づくsushi_item_counterを削除してリセットを行う