### PR TITLE
カウンター編集処理#15

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -215,7 +215,7 @@ body {
 
 .plus-nav {
   position: fixed;
-  bottom: 67px;
+  bottom: 70px;
   right: 0.5rem;
   z-index: 1000;
   font-size: 1.0rem;
@@ -238,7 +238,7 @@ body {
 .btn-nav3 {
   position: fixed;
   bottom: 70px;
-  right: 3.7rem;
+  right: 4.2rem;
   z-index: 1000;
 }
 

--- a/app/controllers/sushi_items_controller.rb
+++ b/app/controllers/sushi_items_controller.rb
@@ -120,7 +120,7 @@ class SushiItemsController < ApplicationController
 
   def update_count
     @sushi_item = SushiItem.find(params[:id])
-    @counter = current_user.counters.order(created_at: :desc).first_or_create!(eaten_at: Time.current)
+    @counter = current_counter || current_user.counters.create!(eaten_at: Time.current)
 
     sushi_counter = @sushi_item.sushi_item_counters.find_or_initialize_by(counter_id: @counter.id)
     sushi_counter.count ||= 0

--- a/app/views/counters/_counter.html.erb
+++ b/app/views/counters/_counter.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "編集",edit_counter_path(counter) %>

--- a/app/views/counters/edit.html.erb
+++ b/app/views/counters/edit.html.erb
@@ -18,7 +18,7 @@
         <p>以下の寿司をカウントしました：</p>
         <ul>
           <% @counter.sushi_item_counters.includes(:sushi_item).each do |sic| %>
-            <li><%= sic.sushi_item.name %>: <%= sic.count %> 貫</li>
+            <li><%= sic.sushi_item.name %>：<%= sic.count %> 貫</li>
           <% end %>
         </ul>
 
@@ -31,4 +31,6 @@
     </div>
   </div>
 </div>
-<%= link_to "カウント画面へ", sushi_items_path, class: "btn btn-navy" %>
+<div class="text-end">
+  <%= link_to "カウント画面へ", use_counter_path(@counter), method: :post, class: "btn btn-navy" %>
+</div>

--- a/app/views/counters/index.html.erb
+++ b/app/views/counters/index.html.erb
@@ -1,1 +1,3 @@
 <h>履歴</h>
+
+<%= render @counters %>

--- a/app/views/sushi_items/_category_and_list.html.erb
+++ b/app/views/sushi_items/_category_and_list.html.erb
@@ -8,7 +8,7 @@
   <div class="plus-nav">
     <%= link_to new_sushi_item_path(return_category_id: @selected_category.id),
         class: "shadow bg-navy text-white rounded-circle d-inline-flex justify-content-center align-items-center",
-        style: "width: 45px; height: 45px;",
+        style: "width: 50px; height: 50px;",
         data: { turbo_frame: "modal_frame" } do %>
           <i class="bi bi-plus-lg fs-5"></i>
         <% end %>

--- a/app/views/sushi_items/index.html.erb
+++ b/app/views/sushi_items/index.html.erb
@@ -4,8 +4,11 @@
 </turbo-frame>
 
 <div class="btn-nav3">
-  <%= link_to "保存画面へ", new_counter_path,
-            class: "btn btn-navy btn-shadow fw-bold" %>
+  <% if session[:counter_update_source] == "edit" %>
+    <%= link_to "保存画面へ", edit_counter_path(@counter),class: "btn btn-navy btn-shadow fw-bold" %>
+  <% else %>
+    <%= link_to "保存画面へ", new_counter_path,class: "btn btn-navy btn-shadow fw-bold" %>
+  <% end %>
 </div>
 
 <div class="btn-nav2">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,9 +7,10 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :counters, only: [:new, :update, :index, :show] do
+  resources :counters, only: [:new, :update, :index, :show, :edit] do
     member do
       delete :reset_items
+      post :use
     end
   end
 


### PR DESCRIPTION
## 概要
カウンター編集画面で編集ができる。
カウンター編集画面から、カウント画面へ行きカウントの編集ができる。
更新後はカウント途中のデータがあれば再度表示させる。
なければ新規作成。

## 実施内容
- 編集画面からカウント画面へ行くときに編集対象のセッション情報を取得
- 更新するときに作成日が最新のセッション情報をセット
- これにより更新後のカウント画面にカウント途中、または新規カウント画面が表示される