### PR TITLE
初期データ画像更新処理修正#16

### DIFF
--- a/app/models/sushi_item.rb
+++ b/app/models/sushi_item.rb
@@ -4,6 +4,7 @@ class SushiItem < ApplicationRecord
   belongs_to :created_by_user, class_name: "User", optional: true
   has_many :sushi_item_counters, dependent: :destroy
   has_one_attached :image
+  has_many :user_sushi_item_images, dependent: :destroy
   attr_accessor :reset_to_default_image
   attr_accessor :remove_image
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,7 @@ class User < ApplicationRecord
   validates :password, presence: true, length: { minimum: 7 }, format: { with: VALID_PASSWORD_REGEX }
   has_many :counters, dependent: :destroy
   has_many :sushi_items, foreign_key: :created_by_user_id, dependent: :nullify
+  has_many :user_sushi_item_images, dependent: :destroy
 
   def create_initial_counter
     counters.create!

--- a/app/models/user_sushi_item_image.rb
+++ b/app/models/user_sushi_item_image.rb
@@ -1,0 +1,7 @@
+class UserSushiItemImage < ApplicationRecord
+  belongs_to :user
+  belongs_to :sushi_item
+  has_one_attached :image
+
+  validates :user_id, uniqueness: { scope: :sushi_item_id }
+end

--- a/app/views/sushi_items/_edit_form.html.erb
+++ b/app/views/sushi_items/_edit_form.html.erb
@@ -34,11 +34,14 @@
         <%= f.label :image, class: "form-label mb-1" %>
         <%= f.file_field :image, class: "form-control" %>
 
-        <% if sushi.image.attached? %>
-          <div class="mt-3">
-            <%= image_tag sushi.image.variant(resize_to_limit: [200, 200]), class: "img-thumbnail mb-3" %>
-          </div>
+        <div class="mt-3">
+        <% user_image = sushi.user_sushi_item_images.find_by(user_id: current_user.id) %>
+        <% if user_image&.image&.attached? %>
+          <%= image_tag user_image.image.variant(resize_to_limit: [200, 200]), class: "img-thumbnail mb-3" %>
+        <% elsif sushi.image.attached? %>
+          <%= image_tag sushi.image.variant(resize_to_limit: [200, 200]), class: "img-thumbnail mb-3" %>
         <% end %>
+        </div>
       </div>
 
       <div class="form-check">

--- a/app/views/sushi_items/_sushi_item.html.erb
+++ b/app/views/sushi_items/_sushi_item.html.erb
@@ -1,16 +1,30 @@
 <% if sushi_item.created_by_user_id == current_user.id || sushi_item.created_by_user_id == nil %>
   <div class="sushi-card" id="sushi_item_<%= sushi_item.id %>">
     <div class="count-display">
-      <%= image_tag sushi_item.image, class: "sushi-img" if sushi_item.image.present?%>
+      <% user_image = sushi_item.user_sushi_item_images.find_by(user_id: current_user.id) %>
+
+      <% if user_image&.image&.attached? %>
+        <%= image_tag user_image.image, class: "sushi-img" %>
+
+      <% elsif sushi_item.created_by_user_id.nil? && sushi_item.image.attached? %>
+        <%= image_tag sushi_item.image, class: "sushi-img" %>
+
+      <% elsif sushi_item.created_by_user_id == current_user.id && sushi_item.image.attached? %>
+        <%= image_tag sushi_item.image, class: "sushi-img" %>
+      <% end %>
+
       <div class="sushi-count" id="count_<%= sushi_item.id %>">
         <%= sushi_item.sushi_item_counters.find_by(counter_id: @counter.id)&.count || 0 %>
       </div>
     </div>
+
     <div class="count-buttons">
       <%= button_to "-", update_count_sushi_item_path(sushi_item, direction: "decrement"), method: :patch, form: { data: { turbo_stream: true }}, class: "count-btn minus" %>
       <%= button_to "+", update_count_sushi_item_path(sushi_item, direction: "increment"), method: :patch, form: { data: { turbo_stream: true }}, class: "count-btn plus" %>
     </div>
+
     <p class="sushi-name"><%= sushi_item.name %></p>
+
     <% if sushi_item.created_by_user_id == current_user.id %>
       <%= link_to "編集", edit_sushi_item_path(sushi_item, category_id: @selected_category.id), data: { turbo_frame: "modal_frame" } %>
       <%= button_to "削除", sushi_item_path(sushi_item), method: :delete, data: { turbo_stream: true, confirm: "本当に削除しますか？" }, class: "btn btn-danger" %>

--- a/db/migrate/20250616025147_create_user_sushi_item_images.rb
+++ b/db/migrate/20250616025147_create_user_sushi_item_images.rb
@@ -1,0 +1,10 @@
+class CreateUserSushiItemImages < ActiveRecord::Migration[7.0]
+  def change
+    create_table :user_sushi_item_images do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :sushi_item, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_06_13_101107) do
+ActiveRecord::Schema[7.0].define(version: 2025_06_16_025147) do
   create_table "active_storage_attachments", charset: "utf8mb3", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -74,6 +74,15 @@ ActiveRecord::Schema[7.0].define(version: 2025_06_13_101107) do
     t.index ["category_id"], name: "index_sushi_items_on_category_id"
   end
 
+  create_table "user_sushi_item_images", charset: "utf8mb3", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "sushi_item_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["sushi_item_id"], name: "index_user_sushi_item_images_on_sushi_item_id"
+    t.index ["user_id"], name: "index_user_sushi_item_images_on_user_id"
+  end
+
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "email", default: "", null: false
@@ -98,4 +107,6 @@ ActiveRecord::Schema[7.0].define(version: 2025_06_13_101107) do
   add_foreign_key "sushi_item_counters", "counters"
   add_foreign_key "sushi_item_counters", "sushi_items"
   add_foreign_key "sushi_items", "categories"
+  add_foreign_key "user_sushi_item_images", "sushi_items"
+  add_foreign_key "user_sushi_item_images", "users"
 end

--- a/test/fixtures/user_sushi_item_images.yml
+++ b/test/fixtures/user_sushi_item_images.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  sushi_item: one
+
+two:
+  user: two
+  sushi_item: two

--- a/test/models/user_sushi_item_image_test.rb
+++ b/test/models/user_sushi_item_image_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UserSushiItemImageTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
初期データの画像を更新した際、ほかのユーザーの画像にも反映されてしまう

## 実施内容
- ユーザーごとに画像を保存するための `user_sushi_item_images` モデルを作成
- 初期データの画像を更新したときのみ、そこに保存されるようにする
- 初期画像に戻す処理でも、 `user_sushi_item_images` から削除してからattachする処理を追加