### PR TITLE
寿司データベース機能実装#18

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -257,7 +257,6 @@ body {
   margin-bottom: 3.5rem; 
 }
 
-
 .mb-7 {
   margin-bottom: 6rem; /* 例えば 64px */
 }
@@ -297,4 +296,30 @@ body {
 
 .pagination>.active>a {		
   background: #93c9ff;	   /*背景の色を変える*/	
+}
+
+.list-group.no-top-rounded li:first-child {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.no-padding-left {
+  padding-left: 0 !important;
+}
+
+.custom-sushi-table {
+  table-layout: fixed;
+  width: 100%;
+
+  th:nth-child(1), td:nth-child(1) { // No.列
+    width: 10%;
+  }
+
+  th:nth-child(2), td:nth-child(2) { // 名前
+    width: 60%;
+  }
+
+  th:nth-child(3), td:nth-child(3) { // 貫数
+    width: 20%;
+  }
 }

--- a/app/javascript/controllers/collapse_persist_controller.js
+++ b/app/javascript/controllers/collapse_persist_controller.js
@@ -1,0 +1,36 @@
+import { Controller } from "@hotwired/stimulus"
+import * as bootstrap from "bootstrap"
+
+export default class extends Controller {
+  static values = { id: String }
+
+  connect() {
+    console.log("✅ collapse-persist connected!")
+
+    this.panel = document.getElementById(this.idValue)
+
+    // 保存された状態を反映（open or closed）
+    const savedState = localStorage.getItem(`collapse-${this.idValue}`)
+    console.log("📦 loaded state:", savedState)
+    if (savedState === "open") {
+      this.panel.classList.add("show")
+    } else {
+      this.panel.classList.remove("show")
+    }
+
+    // Bootstrap Collapse API を使ってイベントを監視
+    const collapse = new bootstrap.Collapse(this.panel, {
+      toggle: false // 勝手に開かないようにする
+    })
+
+    this.panel.addEventListener("shown.bs.collapse", () => {
+      localStorage.setItem(`collapse-${this.idValue}`, "open")
+      console.log("💾 saved state: open")
+    })
+
+    this.panel.addEventListener("hidden.bs.collapse", () => {
+      localStorage.setItem(`collapse-${this.idValue}`, "closed")
+      console.log("💾 saved state: closed")
+    })
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -8,11 +8,13 @@ import ModalCloseHookController from "./modal_close_hook_controller"
 import HelloController from "./hello_controller"
 import FlashController from "./flash_controller"
 import ResetFormController from "./reset_form_controller"
+import CollapsePersistController from "./collapse_persist_controller"
 
 application.register("hello", HelloController)
 application.register("modal", ModalController)
 application.register("modal-close-hook", ModalCloseHookController)
 application.register("reset-form", ResetFormController)
+application.register("collapse-persist", CollapsePersistController)
 
 Stimulus.register("flash", FlashController)
 

--- a/app/models/counter.rb
+++ b/app/models/counter.rb
@@ -6,11 +6,11 @@ class Counter < ApplicationRecord
 
   attribute :saved, :boolean, default: false
 
-  def total_count
+  def total_sushi_count
     sushi_item_counters.sum{|sic| sic.count }
   end
 
-  ransacker :total_count do
+  ransacker :counter_total_count do
     Arel.sql("COALESCE((SELECT SUM(sushi_item_counters.count)
                         FROM sushi_item_counters
                         WHERE sushi_item_counters.counter_id = counters.id), 0)")

--- a/app/views/counters/_counter.html.erb
+++ b/app/views/counters/_counter.html.erb
@@ -4,6 +4,6 @@
     <span class="ms-2"><%= counter.store_name %></span>
   </div>
   <div class="fw-bold">
-    <%= counter.total_count %>貫
+    <%= counter.counter_total_count %>貫
   </div>
 <% end %>

--- a/app/views/counters/_summary_search_form.html.erb
+++ b/app/views/counters/_summary_search_form.html.erb
@@ -1,26 +1,25 @@
-<%= search_form_for q, url: counters_path, method: :get, html: { id: "search-form", data: { controller: "reset-form", reset_form_target: "form" } } do |f| %>
+<%= search_form_for q, url: summary_counters_path, method: :get, html: { id: "search-form", data: { controller: "reset-form", reset_form_target: "form" } } do |f| %>
   <div class="my-3" style="max-width: 800px; margin-left: auto; margin-right: auto;">
     <div class="card shadow-sm">
       <div class="card-header d-flex justify-content-between align-items-center bg-white">
         <div class="d-flex align-items-center">
-          <%= label_tag :sort, "", class: "me-2 mb-0" %>
+          <%= label_tag :sort, "", class: "me-2 mb-0 fw-bold" %>
           <%= select_tag :sort, options_for_select([
-              ['日付（降順）', 'date_desc'],
-              ['日付（昇順）', 'date_asc'],
               ['貫数（降順）', 'count_desc'],
-              ['貫数（昇順）', 'count_asc']
+              ['貫数（昇順）', 'count_asc'],
+              ['寿司名（降順）', 'name_desc'],
+              ['寿司名（昇順）', 'name_asc']
             ], params[:sort]), class: "form-select form-select-sm" %>
         </div>
         <button type="button" class="btn btn-link text-navy fw-bold p-0" data-bs-toggle="collapse" data-bs-target="#filter-panel">
-          絞り込み
+          検索条件
         </button>
       </div>
 
       <div class="collapse" 
-            id="filter-panel"
-            data-controller="collapse-persist"
-            data-collapse-persist-id-value="filter-panel"
-      >
+          id="filter-panel"
+          data-controller="collapse-persist"
+          data-collapse-persist-id-value="filter-panel">
         <div class="card-body">
           <div class="text-end">
             <button type="button" data-action="reset-form#reset" class="btn btn-sm btn-outline-secondary">
@@ -38,6 +37,11 @@
           </div>
 
           <div class="mb-4">
+            <%= f.label :sushi_item_counters_sushi_item_name_cont, "寿司名", class: "form-label mb-1" %>
+            <%= f.text_field :sushi_item_counters_sushi_item_name_cont, class: "form-control" %>
+          </div>
+
+          <div class="mb-4">
             <%= f.label :store_name_cont, "店名", class: "form-label mb-1" %>
             <%= f.text_field :store_name_cont, class: "form-control" %>
           </div>
@@ -45,16 +49,17 @@
           <div class="mb-5">
             <label class="form-label mb-1">貫数</label>
             <div class="d-flex align-items-center gap-2">
-              <%= f.number_field :counter_total_count_gteq, class: "form-control", placeholder: "以上" %>
+              <%= number_field_tag "q[total_count_gteq]", params.dig(:q, :total_count_gteq), class: "form-control", placeholder: "以上" %>
               <span class="mx-1">〜</span>
-              <%= f.number_field :counter_total_count_lteq, class: "form-control", placeholder: "以下" %>
+              <%= number_field_tag "q[total_count_lteq]", params.dig(:q, :total_count_lteq), class: "form-control", placeholder: "以下" %>
             </div>
           </div>
 
-          <div class="text-center mb-2">
-            <%= f.submit "絞り込む", class: "btn btn-navy w-100" %>
-          </div>
+          
 
+          <div class="text-center mb-2">
+            <%= f.submit "検索", class: "btn btn-navy w-100" %>
+          </div>
         </div>
       </div>
     </div>

--- a/app/views/counters/edit.html.erb
+++ b/app/views/counters/edit.html.erb
@@ -21,7 +21,7 @@
           <% end %>
         </ul>
 
-        <p>合計：<%= @counter.total_count %> 貫<p>
+        <p>合計：<%= @counter.total_sushi_count %> 貫<p>
 
         <div class="d-grid">
           <%= f.submit "更新", class: "btn btn-navy" %>

--- a/app/views/counters/new.html.erb
+++ b/app/views/counters/new.html.erb
@@ -21,7 +21,7 @@
           <% end %>
         </ul>
 
-        <p>合計：<%= @counter.total_count %> 貫<p>
+        <p>合計：<%= @counter.total_sushi_count %> 貫<p>
 
         <div class="d-grid">
           <%= f.submit "保存", class: "btn btn-navy" %>

--- a/app/views/counters/summary.html.erb
+++ b/app/views/counters/summary.html.erb
@@ -1,0 +1,83 @@
+<div class="text-center my-3">
+  <h2>寿司データベース</h2>
+</div>
+
+<div class="mb-3" style="max-width: 800px; margin-left: auto; margin-right: auto;">
+  <!-- 食べた寿司TOP3 -->
+  <div class="mb-4">
+    <div class="bg-navy text-white fw-bold text-center py-2 rounded-top">
+      食べた寿司TOP3
+    </div>
+    <ul class="list-group no-top-rounded border-top-0 rounded-bottom">
+      <% @popular_sushis.each do |sushi, count, rank| %>
+        <li class="list-group-item d-flex justify-content-between align-items-center">
+          <div class="fw-bold fs-5">
+            <span><%= rank %>位</span>
+            <span class="ms-3"><%= sushi %></span>
+          </div>
+          <span class="fs-5 fw-bold"><%= count %>貫</span>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+
+  <!-- よく行った店舗TOP3 -->
+  <div class="mb-3">
+    <div class="bg-navy text-white fw-bold text-center py-2 rounded-top">
+      よく行った店舗TOP3
+    </div>
+    <ul class="list-group no-top-rounded border-top-0 rounded-bottom">
+      <% @popular_stores.each do |store, count, rank| %>
+        <li class="list-group-item d-flex justify-content-between align-items-center">
+          <div class="fw-bold fs-5">
+            <span><%= rank %>位</span>
+            <span class="ms-3"><%= store %></span>
+          </div>
+          <span class="fs-5 fw-bold"><%= count %>回</span>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+
+  <div class="mb-4 fs-5">
+    <strong>総貫数:</strong> <%= @total_sushi %> 貫
+  </div>
+</div>
+
+<div data-controller="reset-form">
+  <%= render 'summary_search_form', q: @q %>
+</div>
+
+<div class="mb-6">
+  <div class="card" style="max-width: 800px; margin: 0 auto;">
+    <div class="card-header bg-navy text-white fw-bold position-relative">
+      <div class="w-100 text-center">寿司データ</div>
+    </div>
+
+    <table class="table mb-0 custom-sushi-table">
+      
+      <thead>
+        <tr class="table-primary">
+          <th class="text-end no-padding-left">No.</th>
+          <th class="ps-3">名前</th>
+          <th class="text-end pe-3">貫数</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @sushi_ranks.each do |rank, name, count| %>
+          <tr>
+            <td class="text-end no-padding-left"><%= rank %></td>
+            <td class="ps-3"><%= name %></td>
+            <td class="text-end pe-3"><%= count %></td>
+          </tr>
+        <% end %>
+      </tbody>
+      <tfoot>
+        <tr class="table-primary fw-bold">
+          <td colspan="2" class="text-end">合計</td>
+          <td class="text-end pe-3"><%= @total_sushi_count %></td>
+        </tr>
+      </tfoot>
+    </table>
+  </div>
+</div>  

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -19,7 +19,7 @@
     <% end %>
   </li>
   <li class="nav-item text-center flex-fill">
-    <%= link_to "#", class: "nav-link text-navy" do %>
+    <%= link_to summary_counters_path, class: "nav-link text-navy" do %>
       <i class="bi bi-clipboard-data fs-4"></i><br>
       <small>寿司DB</small>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,9 @@ Rails.application.routes.draw do
       delete :reset_items
       post :use
     end
+    collection do
+      get :summary
+    end
   end
 
   devise_for :users


### PR DESCRIPTION
## 概要
過去の寿司のデータを調べられるページを作成

## 実施内容
- 寿司データベース画面に以下を表示
  - 食べた寿司トップ3
  - 店舗トップ3
  - 累計貫数
  - 詳細検索フォーム

- 詳細検索では各寿司ごとの貫数を検索できる