### PR TITLE
カウント画面見た目の調整#47

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -162,7 +162,9 @@ body {
   border-radius: 12px;
   box-shadow: 0 2px 6px rgba(0,0,0,0.1);
   text-align: center;
-  padding: 10px;
+  padding: 8px;
+  padding-top: 1.3rem;
+  touch-action: manipulation; /* ← ズーム無効 + タップ操作を許可 */
 }
 
 .count-display {
@@ -177,27 +179,65 @@ body {
 .sushi-count {
   font-size: 32px;
   font-weight: bold;
-  position: absolute;
-  top: 10px;
-  left: 50%;
-  transform: translateX(-50%);
   color: black;
+  min-width: 40px;
+  text-align: center;
 }
 
 .count-buttons {
   display: flex;
-  justify-content: space-around;
-  margin-top: 8px;
+  justify-content: center;
+  align-items: center;
+  padding: 0;
+  margin: 0;
 }
 
 .count-btn {
   width: 40px;
   height: 40px;
-  font-size: 20px;
-  font-weight: bold;
   background-color: #0A2D88;
   color: white;
+  border: none;
   border-radius: 6px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0;
+  cursor: pointer;
+
+  font-size: 0; /* ← ボタン内テキストサイズをゼロにしてアイコンだけ表示 */  
+}
+
+.count-btn i {
+  font-size: 40px;     /* アイコンサイズを指定 */
+  line-height: 1;      /* アイコン上下の余白をなくす */
+  vertical-align: middle;
+  pointer-events: none; /* アイコンがクリック妨げないように */
+}
+
+.btn-icon {
+  width: 12.61px;
+  height: 14.86px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  background: transparent;
+}
+
+.btn-icon-form {
+  display: inline-block;
+  margin: 0;
+  padding: 0;
+  height: 14.86px;
+  width: 12.61px;
+}
+
+.action-buttons {
+  background-color: rgba(255, 255, 255, 0.524);
+  display: inline-flex;  
+  border-radius: 8px;
 }
 
 .spsize-category{

--- a/app/controllers/sushi_items_controller.rb
+++ b/app/controllers/sushi_items_controller.rb
@@ -6,6 +6,7 @@ class SushiItemsController < ApplicationController
       @sushi_items = SushiItem.includes(:sushi_item_counters, :category)
         .where(category_id: @selected_category.id)
         .where("created_by_user_id = ? OR created_by_user_id IS NULL", current_user.id)
+        .order("id ASC")
       
       respond_to do |format|
         format.turbo_stream if turbo_frame_request?

--- a/app/views/counters/new.html.erb
+++ b/app/views/counters/new.html.erb
@@ -16,7 +16,7 @@
 
         <p>以下の寿司をカウントしました：</p>
         <ul>
-          <% @counter.sushi_item_counters.includes(:sushi_item).each do |sic| %>
+          <% @counter.sushi_item_counters.includes(:sushi_item).where.not(sushi_item_counters: { count: [nil, "0"] }).each do |sic| %>
             <li><%= sic.sushi_item.name %>：<%= sic.count %> 貫</li>
           <% end %>
         </ul>

--- a/app/views/sushi_items/_edit_form.html.erb
+++ b/app/views/sushi_items/_edit_form.html.erb
@@ -1,5 +1,6 @@
-<div class="container my-4" style="max-width: 500px;">
-  <%= form_with model: sushi, data: { turbo_frame: "modal_frame" }, html: { class: "p-4 border rounded bg-white", multipart: true } do |f| %>
+<div class="mb-2" style="max-width: 500px;">
+  <h1 class="text-center mb-3">寿司編集</h1>
+  <%= form_with model: sushi, data: { turbo_frame: "modal_frame" }, html: { class: "p-2 border rounded bg-white", multipart: true } do |f| %>
     <%= hidden_field_tag :category_id, @selected_category.id %>
     <%= render "shared/errors_messages", resource: sushi %>
     <% if sushi.created_by_user_id == current_user.id %>
@@ -19,7 +20,7 @@
 
         <% if sushi.image.attached? %>
           <div class="mt-3">
-            <%= image_tag sushi.image.variant(resize_to_limit: [200, 200]), class: "img-thumbnail mb-3" %>
+            <%= image_tag sushi.image.variant(resize_to_limit: [150, 150]), class: "img-thumbnail mb-3" %>
           </div>
           <div class="form-check">
             <%= f.check_box :remove_image, { class: "form-check-input" } %>
@@ -35,12 +36,12 @@
         <%= file_field_tag "user_sushi_item_image[image]", class: "form-control" %>
 
         <div class="mt-3">
-        <% user_image = sushi.user_sushi_item_images.find_by(user_id: current_user.id) %>
-        <% if user_image&.image&.attached? %>
-          <%= image_tag user_image.image.variant(resize_to_limit: [200, 200]), class: "img-thumbnail mb-3" %>
-        <% elsif sushi.image.attached? %>
-          <%= image_tag sushi.image.variant(resize_to_limit: [200, 200]), class: "img-thumbnail mb-3" %>
-        <% end %>
+          <% user_image = sushi.user_sushi_item_images.find_by(user_id: current_user.id) %>
+          <% if user_image&.image&.attached? %>
+            <%= image_tag user_image.image.variant(resize_to_limit: [150, 150]), class: "img-thumbnail mb-2" %>
+          <% elsif sushi.image.attached? %>
+            <%= image_tag sushi.image.variant(resize_to_limit: [150, 150]), class: "img-thumbnail mb-2" %>
+          <% end %>
         </div>
       </div>
 

--- a/app/views/sushi_items/_form.html.erb
+++ b/app/views/sushi_items/_form.html.erb
@@ -1,6 +1,6 @@
 <div class="mb-2" style="max-width: 500px;">
   <h1 class="text-center mb-3">新規寿司作成</h1>
-  <%= form_with model: sushi, data: { turbo_frame: "modal_frame" }, html: { class: "p-4 border rounded bg-white" } do |f| %>
+  <%= form_with model: sushi, data: { turbo_frame: "modal_frame" }, html: { class: "p-2 border rounded bg-white" } do |f| %>
     <%= hidden_field_tag :return_category_id, params[:return_category_id] || @selected_category.id %>
     <%= render "shared/errors_messages", resource: sushi %>
     <div class="mb-3">
@@ -19,7 +19,7 @@
   
       <% if sushi.image.attached? %>
         <div class="mt-3">
-          <%= image_tag sushi.image.variant(resize_to_limit: [200, 200]), class: "img-thumbnail mb-3" %>
+          <%= image_tag sushi.image.variant(resize_to_limit: [150, 150]), class: "img-thumbnail mb-3" %>
         </div>
       <% end %>
     </div>

--- a/app/views/sushi_items/_sushi_item.html.erb
+++ b/app/views/sushi_items/_sushi_item.html.erb
@@ -1,5 +1,5 @@
 <% if sushi_item.created_by_user_id == current_user.id || sushi_item.created_by_user_id == nil %>
-  <div class="sushi-card" id="sushi_item_<%= sushi_item.id %>">
+  <div class="sushi-card position-relative d-flex flex-column justify-content-between" id="sushi_item_<%= sushi_item.id %>">
     <div class="count-display">
       <% user_image = sushi_item.user_sushi_item_images.find_by(user_id: current_user.id) %>
 
@@ -12,24 +12,50 @@
       <% elsif sushi_item.created_by_user_id == current_user.id && sushi_item.image.attached? %>
         <%= image_tag sushi_item.image, class: "sushi-img" %>
       <% end %>
+    </div>
 
-      <div class="sushi-count" id="count_<%= sushi_item.id %>">
-        <%= sushi_item.sushi_item_counters.find_by(counter_id: @counter.id)&.count || 0 %>
+    <div class="sushi-footer mt-auto text-center">
+      <div class="sushi-name fw-bold">
+        <%= sushi_item.name %>
+      </div>
+  
+      <div class="count-buttons d-flex justify-content-center align-items-center gap-2">
+        <%= button_to update_count_sushi_item_path(sushi_item, direction: "decrement"),
+              method: :patch,
+              form: { data: { turbo_stream: true } },
+              class: "count-btn minus" do %>
+          <i class="bi bi-dash"></i>
+        <% end %>
+      
+        <div class="sushi-count" id="count_<%= sushi_item.id %>">
+          <%= sushi_item.sushi_item_counters.find_by(counter_id: @counter.id)&.count || 0 %>
+        </div>
+      
+        <%= button_to update_count_sushi_item_path(sushi_item, direction: "increment"),
+              method: :patch,
+              form: { data: { turbo_stream: true } },
+              class: "count-btn plus" do %>
+          <i class="bi bi-plus"></i>
+        <% end %>
       </div>
     </div>
 
-    <div class="count-buttons">
-      <%= button_to "-", update_count_sushi_item_path(sushi_item, direction: "decrement"), method: :patch, form: { data: { turbo_stream: true }}, class: "count-btn minus" %>
-      <%= button_to "+", update_count_sushi_item_path(sushi_item, direction: "increment"), method: :patch, form: { data: { turbo_stream: true }}, class: "count-btn plus" %>
-    </div>
-
-    <p class="sushi-name"><%= sushi_item.name %></p>
-
-    <% if sushi_item.created_by_user_id == current_user.id %>
-      <%= link_to "編集", edit_sushi_item_path(sushi_item, category_id: @selected_category.id), data: { turbo_frame: "modal_frame" } %>
-      <%= button_to "削除", sushi_item_path(sushi_item), method: :delete, data: { turbo_stream: true, confirm: "本当に削除しますか？" }, class: "btn btn-danger" %>
-    <% elsif sushi_item.created_by_user_id.nil? %>
-      <%= link_to "編集", edit_sushi_item_path(sushi_item, category_id: @selected_category.id), data: { turbo_frame: "modal_frame" } %>
+    <% if sushi_item.created_by_user_id == current_user.id || sushi_item.created_by_user_id.nil? %>
+      <div class="action-buttons rounded"
+          style="position: absolute; top: 0.4rem; right: 0.4rem; display: inline-flex; align-items: center; gap: 0.5rem;">
+        <%= link_to "", edit_sushi_item_path(sushi_item, category_id: @selected_category.id), 
+            data: { turbo_frame: "modal_frame" }, 
+            class: "nav-link far fa-edit text-navy"%>
+        <% if sushi_item.created_by_user_id == current_user.id %>
+          <%= form_with url: sushi_item_path(sushi_item), method: :delete,
+              data: { turbo_stream: true },
+              class: "btn-icon-form", local: true do %>
+            <button type="submit" class="btn-icon text-navy" data-confirm="本当に削除しますか？">
+              <i class="far fa-trash-alt"></i>
+            </button>
+          <% end %>
+        <% end %>
+      </div>
     <% end %>
   </div>
 <% end %>

--- a/app/views/sushi_items/edit.html.erb
+++ b/app/views/sushi_items/edit.html.erb
@@ -1,4 +1,8 @@
 <%= turbo_frame_tag 'modal_frame' do %>
   <%= render 'edit_form', sushi: @sushi_item %>
-  <button type="button" class="btn btn-secondary" data-action="click->modal#close">キャンセル</button>
+  <div class="text-center">
+    <button type="button" class="btn btn-secondary" data-action="click->modal#close">
+      キャンセル
+    </button>
+  </div>
 <% end %>

--- a/app/views/sushi_items/update_count.turbo_stream.erb
+++ b/app/views/sushi_items/update_count.turbo_stream.erb
@@ -1,7 +1,7 @@
 <%= turbo_stream.replace "count_#{@sushi_item.id}",
       partial: "sushi_items/sushi_item",
       locals: { sushi_item: @sushi_item, counter: @counter  } do %>
-  <div id="count_<%= @sushi_item.id %>">
+  <div class="sushi-count" id="count_<%= @sushi_item.id %>">
     <%= @sushi_item.sushi_item_counters.find_by(counter_id: @counter.id)&.count || 0 %>
   </div>
 <% end %>


### PR DESCRIPTION
## 概要
カウント画面の見た目を調整

## 実施内容
- 編集削除ボタンをアイコンに変更
- 編集削除ボタンを右上に表示
- カウント数をカウントボタンの間に表示
- +-をアイコンに変更
- スマホでのダブルタップズームを無効化