### PR TITLE
スクロール位置保存修正2

### DIFF
--- a/app/javascript/controllers/scroll_controller.js
+++ b/app/javascript/controllers/scroll_controller.js
@@ -3,6 +3,8 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   connect() {
+    if (window.location.pathname.includes("/gachas/result")) return;
+    if (window.location.pathname.includes("/user_gacha_lists")) return;
     const key = `scrollY:${location.pathname}`;
     const y = sessionStorage.getItem(key);
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,7 @@
     <link href="https://fonts.googleapis.com/css2?family=M+PLUS+1p:wght@100;300;400;700;900&display=swap" rel="stylesheet">
   </head>
 
-<body data-controller="<%= 'scroll' unless controller_name == 'gachas' && action_name == 'result' || controller_name == 'user_gacha_lists' && action_name == 'index' %>">
+<body data-controller="scroll">
   <%= render 'shared/header' %>
   <%= render 'shared/flash_messages' %>
 


### PR DESCRIPTION
## 概要
検索後のスクロール位置保存
## 実施内容
- application.html.erbでscrollをページによって条件分岐していた記載を削除
- scroll_controllerで条件分岐
- body内は最初のページリロードしか評価されないため実行されなかった