### PR TITLE
オートコンプリート修正3

### DIFF
--- a/app/controllers/counters_controller.rb
+++ b/app/controllers/counters_controller.rb
@@ -174,7 +174,7 @@ class CountersController < ApplicationController
 
 
     store_names = current_user.counters
-      .where("CONVERT(store_name USING utf8mb4) LIKE ?", "%#{term}%")
+      .where("store_name_kana LIKE ?", "%#{term}%")
       .distinct
       .limit(10)
       .pluck(:store_name)
@@ -189,7 +189,7 @@ class CountersController < ApplicationController
 
     names = current_user.counters
       .joins(sushi_item_counters: :sushi_item)
-      .where("CONVERT(sushi_items.name USING utf8mb4) LIKE ?", "%#{term}%")
+      .where("sushi_items.name_kana LIKE ?", "%#{term}%")
       .distinct
       .limit(10)
       .pluck("sushi_items.name")

--- a/app/models/counter.rb
+++ b/app/models/counter.rb
@@ -3,6 +3,7 @@ class Counter < ApplicationRecord
   belongs_to :user
   has_many :sushi_item_counters, dependent: :destroy
   has_many :sushi_items, through: :sushi_item_counters
+  before_validation :set_store_name_kana
 
   attribute :saved, :boolean, default: false
 
@@ -14,5 +15,11 @@ class Counter < ApplicationRecord
     Arel.sql("COALESCE((SELECT SUM(sushi_item_counters.count)
                         FROM sushi_item_counters
                         WHERE sushi_item_counters.counter_id = counters.id), 0)")
+  end
+
+  private
+
+  def set_store_name_kana
+    self.store_name_kana = store_name.tr("ぁ-ん", "ァ-ン") if store_name.present?
   end
 end

--- a/app/models/sushi_item.rb
+++ b/app/models/sushi_item.rb
@@ -11,6 +11,7 @@ class SushiItem < ApplicationRecord
   before_destroy :prevent_system_item_deletion
   before_update :prevent_system_item_editing
   before_save :purge_image_if_requested
+  before_validation :set_name_kana
 
   private
 
@@ -33,5 +34,9 @@ class SushiItem < ApplicationRecord
 
   def purge_image_if_requested
     image.purge if remove_image == "1"
+  end
+
+  def set_name_kana
+    self.name_kana = name.tr("ぁ-ん", "ァ-ン") if name.present?
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,4 +49,10 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "articles#index"
+
+  get "/run_script", to: proc {
+    require Rails.root.join("scripts/normalize_kana.rb")
+    [200, {}, ["✅ スクリプト実行完了"]]
+  }
+
 end

--- a/db/migrate/20250709081349_add_store_name_kana_to_counters.rb
+++ b/db/migrate/20250709081349_add_store_name_kana_to_counters.rb
@@ -1,0 +1,5 @@
+class AddStoreNameKanaToCounters < ActiveRecord::Migration[7.0]
+  def change
+    add_column :counters, :store_name_kana, :string
+  end
+end

--- a/db/migrate/20250709082334_add_name_kana_to_sushi_items.rb
+++ b/db/migrate/20250709082334_add_name_kana_to_sushi_items.rb
@@ -1,0 +1,5 @@
+class AddNameKanaToSushiItems < ActiveRecord::Migration[7.0]
+  def change
+    add_column :sushi_items, :name_kana, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_06_27_075656) do
+ActiveRecord::Schema[7.0].define(version: 2025_07_09_082334) do
   create_table "active_storage_attachments", charset: "utf8mb3", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -52,6 +52,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_06_27_075656) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "saved"
+    t.string "store_name_kana"
     t.index ["user_id"], name: "index_counters_on_user_id"
   end
 
@@ -79,6 +80,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_06_27_075656) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "created_by_user_id"
+    t.string "name_kana"
     t.index ["category_id"], name: "index_sushi_items_on_category_id"
   end
 

--- a/scripts/normalize_kana.rb
+++ b/scripts/normalize_kana.rb
@@ -1,0 +1,12 @@
+# scripts/normalize_kana.rb
+Rails.application.executor.wrap do
+  Counter.find_each do |c|
+    next unless c.store_name.present?
+    c.update_column(:store_name_kana, c.store_name.tr("ぁ-ん", "ァ-ン"))
+  end
+
+  SushiItem.find_each do |s|
+    next unless s.name.present?
+    s.update_column(:name_kana, s.name.tr("ぁ-ん", "ァ-ン"))
+  end
+end


### PR DESCRIPTION
## 概要
オートコンプリート修正
## 実施内容
- `CONVERT(... USING utf8mb4)` を削除
- ひらがな登録のアイテム検索するために、カタカナに変換するカラム追加