### PR TITLE
データベースの軽量化

### DIFF
--- a/app/controllers/health_check_controller.rb
+++ b/app/controllers/health_check_controller.rb
@@ -1,0 +1,7 @@
+class HealthCheckController < ApplicationController
+  skip_before_action :auto_guest_sign_in
+
+  def ping
+    render plain: 'OK', status: :ok
+  end
+end

--- a/app/views/health_check/ping.html.erb
+++ b/app/views/health_check/ping.html.erb
@@ -1,0 +1,2 @@
+<h1>HealthCheck#ping</h1>
+<p>Find me in app/views/health_check/ping.html.erb</p>

--- a/app/views/shared/_guest_user_message.html.erb
+++ b/app/views/shared/_guest_user_message.html.erb
@@ -1,4 +1,4 @@
-<% if current_user&.guest? && request.path != "/users/sign_in" && request.path != "/users/sign_up" && request.path != user_registration_path && request.path != explanation_path%>
+<% if current_user&.guest? && request.path != "/users/sign_in" && request.path != "/users/sign_up" && request.path != user_registration_path && request.path != explanation_path && request.path != ping_path %>
   <div class="d-flex justify-content-center my-4 ms-2 me-2">
     <div class="border-navy rounded p-2 text-center bg-white" style="max-width: 500px;">
       <h5 class="smahosize fw-bold my-2">ゲストユーザーで利用中です。</h5>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   get "terms", to: "homes#terms"
   get "privacy", to: "homes#privacy"
   get "explanation", to: "homes#explanation" 
+  get '/ping', to: 'health_check#ping'
 
   #get "/admin/normalize_kana", to: "admin#normalize_kana"
 

--- a/spec/requests/health_check_spec.rb
+++ b/spec/requests/health_check_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe "HealthChecks", type: :request do
+  describe "GET /ping" do
+    it "returns http success" do
+      get "/health_check/ping"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/views/health_check/ping.html.erb_spec.rb
+++ b/spec/views/health_check/ping.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "health_check/ping.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 概要
neonのDB接続時間が上限になってしまったため、設定を修正

## 実施内容
スリープ対策でアクセスするたびにオートゲストログインが実行されてデータが上限まで達してしまっていたと仮定し、アクセスページを軽いページに変更