### PR TITLE
OGPのmeta-tagsで画像を動的に表示#31

### DIFF
--- a/app/helpers/ogp_helper.rb
+++ b/app/helpers/ogp_helper.rb
@@ -9,14 +9,14 @@ module OgpHelper
         title: :title,
         type: "website",
         url: request.original_url,
-        image: image_url("/ogp_default.png"),
+        image: content_for?(:image) ? content_for(:image) : image_url("/ogp_default.png"),
         site_name: :site,
         description: :description,
         locale: "ja_JP"
       },
       twitter: {
         card: "summary_large_image",
-        image: image_url("/ogp_default.png")
+        image: content_for?(:image) ? content_for(:image) : image_url("/ogp_default.png")
       }
     }
   end

--- a/app/views/gachas/result.html.erb
+++ b/app/views/gachas/result.html.erb
@@ -22,7 +22,8 @@
           </div>
           <strong class="d-block mt-2"><h2><%= item.name %></h2></strong>
           <div class="d-flex justify-content-center gap-3 mt-3">
-            <%= link_to "https://twitter.com/share?url=https://sushi-counter.com/&text=「#{item.name}」を獲得！", title: 'X', target: '_blank', class: 'btn btn-dark text-white btn-sm' do %>
+            <%= link_to "https://twitter.com/intent/tweet?text=#{ERB::Util.url_encode("「#{item.name}」を獲得！ #寿司カウンター")}&url=https://sushi-counter.com/",
+                title: 'Xでシェア', target: '_blank', class: 'btn btn-dark text-white btn-sm' do %>
               <i class="bi bi-twitter-x"></i>
             <% end %>
             <div class="line-it-button" data-lang="ja" data-type="share-b" data-env="REAL" data-url="https://sushi-counter.com" data-color="default" data-size="small" data-count="false" data-ver="3" style="display: none;"></div>
@@ -39,12 +40,6 @@
 
 <% main_result = @results.last %>
 
-<% content_for :og_tags do %>
-  <meta property="og:title" content="「<%= main_result.name %>」を獲得！" />
-  <meta property="og:description" content="寿司カウンターで「<%= main_result.name %>」を引きました。" />
-  <meta property="og:image" content="<%= url_for(main_result.image) %>" />
-  <meta property="og:url" content="<%= request.original_url %>" />
-  <meta property="og:type" content="website" />
-  <meta name="twitter:card" content="summary_large_image" />
-<% end %>
-
+<% content_for :title, "「#{main_result.name}」を獲得！" %>
+<% content_for :description, "寿司カウンターで「#{main_result.name}」を引きました。" %>
+<% content_for :image, main_result.image.attached? ? rails_blob_url(main_result.image, only_path: false) : image_url("ogp_default.png") %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,10 +6,6 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= display_meta_tags(default_meta_tags) %>
-    <% if content_for?(:og_tags) %>
-      <%= yield :og_tags %>
-    <% end %>
-
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", type: "module", "data-turbo-track": "reload" %>


### PR DESCRIPTION
# 概要
result 画面で結果をシェアしたときに画像が動的に表示されるように修正
# 実施内容
- ogp_helperの内容を修正
- resultビューで:imageを設定