### PR TITLE
ガチャ画像共有用のページを作成

### DIFF
--- a/app/models/user_gacha_list.rb
+++ b/app/models/user_gacha_list.rb
@@ -1,4 +1,12 @@
 class UserGachaList < ApplicationRecord
   belongs_to :user
   belongs_to :gacha_list
+
+  before_create :generate_public_token
+
+  private
+
+  def generate_public_token
+    self.public_token ||= SecureRandom.uuid
+  end
 end

--- a/app/views/gachas/public_result.html.erb
+++ b/app/views/gachas/public_result.html.erb
@@ -1,0 +1,31 @@
+<% if @results.last %>
+  <% content_for :title, "「#{@results.last.gacha_list.name}」を獲得！" %>
+  <% content_for :description, "寿司カウンターで「#{@results.last.gacha_list.name}」を引きました。" %>
+  <% content_for :image, @results.last.gacha_list.image.attached? ? rails_blob_url(@results.last.gacha_list.image, host: request.base_url) : image_url("ogp_default.png") %>
+<% else %>
+  <% content_for :title, "ガチャ結果" %>
+  <% content_for :description, "寿司カウンターのガチャ結果を表示します。" %>
+  <% content_for :image, image_url("ogp_default.png") %>
+<% end %>
+
+<h2><%= @user.name %>さんのガチャ結果</h2>
+
+<div class="row">
+  <% if @results.last %>
+    <% record = @results.last %>
+    <div class="col-4 mb-3">
+      <div class="card">
+        <% if record.gacha_list.image.attached? %>
+          <%= image_tag record.gacha_list.image.variant(resize_to_limit: [300, 300]) %>
+        <% else %>
+          <%= image_tag "default_gacha.png", size: "300x300" %>
+        <% end %>
+        <div class="card-body text-center">
+          <h5 class="card-title"><%= record.gacha_list.name %></h5>
+          <p><%= I18n.t("activerecord.attributes.gacha_list.rarity.#{record.gacha_list.rarity}") %></p>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</div>
+

--- a/app/views/gachas/result.html.erb
+++ b/app/views/gachas/result.html.erb
@@ -1,8 +1,13 @@
 <% if @results.last %>
-  <% content_for :title, "「#{@results.last.name}」を獲得！" %>
-  <% content_for :description, "寿司カウンターで「#{@results.last.name}」を引きました。" %>
-  <% content_for :image, @results.last.image.attached? ? rails_blob_url(@results.last.image, host: request.base_url) : image_url("ogp_default.png") %>
+  <% content_for :title, "「#{@results.last.gacha_list.name}」を獲得！" %>
+  <% content_for :description, "寿司カウンターで「#{@results.last.gacha_list.name}」を引きました。" %>
+  <% content_for :image, @results.last.gacha_list.image.attached? ? rails_blob_url(@results.last.gacha_list.image, host: request.base_url) : image_url("ogp_default.png") %>
+<% else %>
+  <% content_for :title, "ガチャ結果" %>
+  <% content_for :description, "寿司カウンターのガチャ結果を表示します。" %>
+  <% content_for :image, image_url("ogp_default.png") %>
 <% end %>
+
 
 
 <% content_for :title, "ガチャ結果" %>
@@ -14,26 +19,26 @@
     <div class="d-flex flex-wrap justify-content-center">
       <% @results.each do |item| %>
         <div class="m-3 text-center">
-          <% rarity_class = case item.rarity
-            when 'normal' then "rarity-#{item.rarity}"
+          <% rarity_class = case item.gacha_list.rarity
+            when 'normal' then "rarity-#{item.gacha_list.rarity}"
             when 'rare' then 'bg-primary text-white'
-            when 'super_rare' then "rarity-#{item.rarity}"
+            when 'super_rare' then "rarity-#{item.gacha_list.rarity}"
             when 'special' then 'bg-warning text-dark'
           end %>
           <div class="position-relative d-inline-block">
-            <%= image_tag item.image, size: "400x400", class: "img-thumbnail" if item.image.attached? %>
+            <%= image_tag item.gacha_list.image, size: "400x400", class: "img-thumbnail" if item.gacha_list.image.attached? %>
             <div class="rarity-badge position-absolute top-0 end-0 px-2 py-1 mt-2 me-2 small rounded <%= rarity_class %>">
-              <%= I18n.t("activerecord.attributes.gacha_list.rarity.#{item.rarity}") %>
+              <%= I18n.t("activerecord.attributes.gacha_list.rarity.#{item.gacha_list.rarity}") %>
             </div>
             
           </div>
-          <strong class="d-block mt-2"><h2><%= item.name %></h2></strong>
+          <strong class="d-block mt-2"><h2><%= item.gacha_list.name %></h2></strong>
           <div class="d-flex justify-content-center gap-3 mt-3">
-            <%= link_to "https://twitter.com/intent/tweet?text=#{ERB::Util.url_encode("「#{item.name}」を獲得！ #寿司カウンター")}&url=https://sushi-counter.com/",
+            <%= link_to "https://twitter.com/intent/tweet?text=#{ERB::Util.url_encode("「#{item.gacha_list.name}」を獲得！ #寿司カウンター")}&url=#{CGI.escape(public_result_gachas_url(public_token: item.public_token))}",
                 title: 'Xでシェア', target: '_blank', class: 'btn btn-dark text-white btn-sm' do %>
               <i class="bi bi-twitter-x"></i>
             <% end %>
-            <div class="line-it-button" data-lang="ja" data-type="share-b" data-env="REAL" data-url="https://sushi-counter.com" data-color="default" data-size="small" data-count="false" data-ver="3" style="display: none;"></div>
+            <div class="line-it-button" data-lang="ja" data-type="share-b" data-env="REAL" data-url="<%= public_result_gachas_url(public_token: item.public_token) %>" data-color="default" data-size="small" data-count="false" data-ver="3" style="display: none;"></div>
             <script src="https://www.line-website.com/social-plugins/js/thirdparty/loader.min.js" async="async" defer="defer"></script>
           </div>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
   resource :gachas, only: [:show] do
     post :draw, on: :collection
     get :result
+    get 'public_result/:public_token', to: 'gachas#public_result', as: :public_result
   end
 
   delete "gachas/result", to: "gachas#destroy_session", as: :destroy_session

--- a/db/migrate/20250725100957_add_public_token_to_user_gacha_lists.rb
+++ b/db/migrate/20250725100957_add_public_token_to_user_gacha_lists.rb
@@ -1,0 +1,6 @@
+class AddPublicTokenToUserGachaLists < ActiveRecord::Migration[7.0]
+  def change
+    add_column :user_gacha_lists, :public_token, :string
+    add_index :user_gacha_lists, :public_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_07_16_085202) do
+ActiveRecord::Schema[7.0].define(version: 2025_07_25_100957) do
   create_table "active_storage_attachments", charset: "utf8mb3", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -89,7 +89,9 @@ ActiveRecord::Schema[7.0].define(version: 2025_07_16_085202) do
     t.bigint "gacha_list_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "public_token"
     t.index ["gacha_list_id"], name: "index_user_gacha_lists_on_gacha_list_id"
+    t.index ["public_token"], name: "index_user_gacha_lists_on_public_token", unique: true
     t.index ["user_id"], name: "index_user_gacha_lists_on_user_id"
   end
 


### PR DESCRIPTION
## 概要
- ガチャ結果を画像付きで共有できるようにしたい。
- result画面はゲストユーザーがアクセスできないため画像にアクセスできない。
- 画像アクセス用のページを作成

## 実施内容
- user_gacha_listsにpublic_tokenカラムを生成
- ランダムに生成されたpublic_tokenから共有用のページにアクセスできるように実装
- public_resultページ作成
- 共有ボタンのリンクをpublic_result_gachasに設定