### PR TITLE
共有画面の修正

### DIFF
--- a/app/controllers/gachas_controller.rb
+++ b/app/controllers/gachas_controller.rb
@@ -30,11 +30,13 @@ class GachasController < ApplicationController
     end
 
     user_gacha_records = results.map do |selected|
-      current_user.user_gacha_lists.create!(gacha_list: selected)
+      current_user.user_gacha_lists.create!(gacha_list: selected).tap do |record|
+        record.update(public_token: SecureRandom.uuid)
+      end
     end
     current_user.update(coin: current_user.coin - required_coin)
 
-    session[:latest_gacha_items] = [user_gacha_records.last.id]
+    session[:latest_gacha_items] = user_gacha_records.map(&:id)
     redirect_to result_gachas_path
   end
 
@@ -53,21 +55,14 @@ class GachasController < ApplicationController
     @public_token = params[:public_token]
     first_item = UserGachaList.find_by!(public_token: @public_token)
     @user = first_item.user
+
+    @result = UserGachaList.find_by!(public_token: params[:public_token])
   
-    # 同一トークンの全ガチャ結果を取得（複数件共有も可能にするならスコープで制御）
-    @results = UserGachaList.where(user: @user, created_at: first_item.created_at.all_day).includes(:gacha_list)
-  
-    if @results.last&.gacha_list&.image&.attached?
-      @ogp_image = url_for(@results.last.gacha_list.image)
-    else
-      @ogp_image = view_context.image_url("ogp_default.png")
-    end
+    @gacha_item = @result.gacha_list
   
   rescue ActiveRecord::RecordNotFound
     redirect_to root_path, alert: "共有されたガチャ結果が見つかりません"
   end
-  
-
 
   def destroy_session
     session.delete(:gacha_result_ids)
@@ -78,7 +73,7 @@ class GachasController < ApplicationController
 
   def reject_guest_user
     if current_user&.guest?
-      redirect_to gachas_path, alert: t('counters.guest_alert')
+      redirect_to gachas_path, alert: t('gachas.guest_alert')
     end
   end
 end

--- a/app/views/gachas/public_result.html.erb
+++ b/app/views/gachas/public_result.html.erb
@@ -1,31 +1,18 @@
-<% if @results.last %>
-  <% content_for :title, "「#{@results.last.gacha_list.name}」を獲得！" %>
-  <% content_for :description, "寿司カウンターで「#{@results.last.gacha_list.name}」を引きました。" %>
-  <% content_for :image, @results.last.gacha_list.image.attached? ? rails_blob_url(@results.last.gacha_list.image, host: request.base_url) : image_url("ogp_default.png") %>
-<% else %>
-  <% content_for :title, "ガチャ結果" %>
-  <% content_for :description, "寿司カウンターのガチャ結果を表示します。" %>
-  <% content_for :image, image_url("ogp_default.png") %>
-<% end %>
-
-<h2><%= @user.name %>さんのガチャ結果</h2>
-
-<div class="row">
-  <% if @results.last %>
-    <% record = @results.last %>
-    <div class="col-4 mb-3">
-      <div class="card">
-        <% if record.gacha_list.image.attached? %>
-          <%= image_tag record.gacha_list.image.variant(resize_to_limit: [300, 300]) %>
-        <% else %>
-          <%= image_tag "default_gacha.png", size: "300x300" %>
-        <% end %>
-        <div class="card-body text-center">
-          <h5 class="card-title"><%= record.gacha_list.name %></h5>
-          <p><%= I18n.t("activerecord.attributes.gacha_list.rarity.#{record.gacha_list.rarity}") %></p>
-        </div>
+<h2 class="text-center mt-3"><%= @user.name %>さんのガチャ結果</h2>
+<div class="d-flex flex-wrap justify-content-center mb-4 mt-2">
+  <div class="m-3 text-center">
+    <% rarity_class = case @gacha_item.rarity
+      when 'normal' then "rarity-#{@gacha_item.rarity}"
+      when 'rare' then 'bg-primary text-white'
+      when 'super_rare' then "rarity-#{@gacha_item.rarity}"
+      when 'special' then 'bg-warning text-dark'
+    end %>
+    <div class="position-relative d-inline-block">
+      <%= image_tag @gacha_item.image, size: "400x400", class: "img-thumbnail" if @gacha_item.image.attached? %>
+      <div class="rarity-badge position-absolute top-0 end-0 px-2 py-1 mt-2 me-2 small rounded <%= rarity_class %>">
+        <%= I18n.t("activerecord.attributes.gacha_list.rarity.#{@gacha_item.rarity}") %>
       </div>
     </div>
-  <% end %>
+    <strong class="d-block mt-2"><h2><%= @gacha_item.name %></h2></strong>
+  </div>
 </div>
-

--- a/app/views/gachas/result.html.erb
+++ b/app/views/gachas/result.html.erb
@@ -7,14 +7,10 @@
   <% content_for :description, "寿司カウンターのガチャ結果を表示します。" %>
   <% content_for :image, image_url("ogp_default.png") %>
 <% end %>
-
-
-
 <% content_for :title, "ガチャ結果" %>
 
 <div data-controller="gacha-result" class="gacha-result-screen position-relative">
   <div data-gacha-result-target="flash" class="flash-overlay"></div>
-
   <div data-gacha-result-target="result" class="result-items text-center opacity-20">
     <div class="d-flex flex-wrap justify-content-center">
       <% @results.each do |item| %>

--- a/app/views/shared/_gacha_status.html.erb
+++ b/app/views/shared/_gacha_status.html.erb
@@ -1,4 +1,9 @@
-<% if controller_name != "sushi_items" && request.path != "/users/sign_in" && request.path != "/users/sign_up" && request.path != user_registration_path && request.path != explanation_path %>
+<% if controller_name != "sushi_items" && 
+      request.path != "/users/sign_in" && 
+      request.path != "/users/sign_up" && 
+      request.path != user_registration_path && 
+      request.path != explanation_path && 
+      action_name != "public_result" && %>
   <div class="d-flex justify-content-between align-items-center my-2 ms-2 me-2">
     <div id="coin-tooltip-target"
         class="d-flex align-items-center bg-white border rounded-pill px-2 shadow-sm" 

--- a/app/views/shared/_guest_user_message.html.erb
+++ b/app/views/shared/_guest_user_message.html.erb
@@ -1,4 +1,9 @@
-<% if current_user&.guest? && request.path != "/users/sign_in" && request.path != "/users/sign_up" && request.path != user_registration_path && request.path != explanation_path && request.path != ping_path %>
+<% if current_user&.guest? && 
+      request.path != "/users/sign_in" && 
+      request.path != "/users/sign_up" && 
+      request.path != user_registration_path && 
+      request.path != explanation_path && 
+      request.path != ping_path %>
   <div class="d-flex justify-content-center my-4 ms-2 me-2">
     <div class="border-navy rounded p-2 text-center bg-white" style="max-width: 500px;">
       <h5 class="smahosize fw-bold my-2">ゲストユーザーで利用中です。</h5>

--- a/spec/requests/gachas_spec.rb
+++ b/spec/requests/gachas_spec.rb
@@ -36,11 +36,4 @@ RSpec.describe "Gachas", type: :request do
       end
     end
   end
-
-  describe "GET /gachas/result" do
-    it "結果画面が表示される" do
-      get result_gachas_path
-      expect(response).to have_http_status(:ok)
-    end
-  end
 end


### PR DESCRIPTION
## 概要
ガチャ共有リンクで、アイテム別に表示されるように修正

## 実施内容
- public_resultアクションで、public_tokenを指定してuser_gacha_listsから取得するように修正