### PR TITLE
パスワード表示・非表示ボタン実装#104

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,3 +15,6 @@ AllCops:
 require:
   - rubocop-rails
 
+Style/ClassAndModuleChildren:
+  Enabled: false
+

--- a/Gemfile
+++ b/Gemfile
@@ -65,9 +65,9 @@ group :development, :test do
   gem 'rubocop', require: false
   gem 'rubocop-rails', require: false
 
-  gem 'rspec-rails'
   gem 'factory_bot_rails'
   gem 'faker'
+  gem 'rspec-rails'
 end
 
 group :development do
@@ -84,8 +84,8 @@ end
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
-  gem "selenium-webdriver"
   gem 'rspec_junit_formatter'
+  gem "selenium-webdriver"
   gem 'simplecov', require: false
 end
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -584,3 +584,23 @@ body {
   height: auto;
   width: 200px;
 }
+
+.password-wrapper {
+  position: relative;
+
+  .form-control {
+    padding-right: 2.5rem;
+    border-radius: 0.4rem !important; // 全角丸
+  }
+
+  .password-toggle-icon {
+    position: absolute;
+    top: 50%;
+    right: 1rem;
+    transform: translateY(-50%);
+    cursor: pointer;
+    z-index: 5;
+    color: #6c757d; // Bootstrapのtext-muted風
+    font-size: 1.25rem;
+  }
+}

--- a/app/controllers/counters_controller.rb
+++ b/app/controllers/counters_controller.rb
@@ -51,7 +51,7 @@ class CountersController < ApplicationController
         session.delete(:counter_update_source)
         redirect_to counters_path, notice: t('counters.update_notice')
       else 
-        redirect_to counters_path, notice: "保存しました"
+        redirect_to counters_path, notice: t('counters.update_else_notice')
       end
     else
       render action_from_source(params[:counter][:update_source]), status: :unprocessable_entity

--- a/app/controllers/gachas_controller.rb
+++ b/app/controllers/gachas_controller.rb
@@ -43,12 +43,6 @@ class GachasController < ApplicationController
   def result
     ids = session[:latest_gacha_items] || []
     @results = UserGachaList.includes(:gacha_list).where(id: ids)
-  
-    if (last_item = @results.last)&.gacha_list&.image&.attached?
-      @og_image = url_for(last_item.gacha_list.image)
-    else
-      @og_image = view_context.image_url("ogp_default.png")
-    end
   end
 
   def public_result
@@ -57,11 +51,10 @@ class GachasController < ApplicationController
     @user = first_item.user
 
     @result = UserGachaList.find_by!(public_token: params[:public_token])
-  
+
     @gacha_item = @result.gacha_list
-  
-    rescue ActiveRecord::RecordNotFound
-      redirect_to root_path, alert: "共有されたガチャ結果が見つかりません"
+  rescue ActiveRecord::RecordNotFound
+    redirect_to root_path, alert: t('public_result_alert')
   end
 
   def destroy_session

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -3,7 +3,7 @@ class Users::PasswordsController < Devise::PasswordsController
 
   protected
 
-  def after_sending_reset_password_instructions_path_for(resource_name)
+  def after_sending_reset_password_instructions_path_for(_resource_name)
     password_reset_done_path
   end
 end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -25,6 +25,9 @@ application.register("modal-close-hook", ModalCloseHookController)
 import ModalController from "./modal_controller"
 application.register("modal", ModalController)
 
+import PasswordToggleController from "./password_toggle_controller"
+application.register("password-toggle", PasswordToggleController)
+
 import ResetFormController from "./reset_form_controller"
 application.register("reset-form", ResetFormController)
 

--- a/app/javascript/controllers/password_toggle_controller.js
+++ b/app/javascript/controllers/password_toggle_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus"
+
+// HTML上で data-controller="password-toggle" を付けた要素に対応
+export default class extends Controller {
+  static targets = ["input", "icon"]
+
+  toggle() {
+    const input = this.inputTarget
+    const icon = this.iconTarget
+
+    const isHidden = input.type === "password"
+    input.type = isHidden ? "text" : "password"
+
+    // アイコン切り替え（Bootstrap Icons想定）
+    icon.classList.toggle("bi-eye-slash", !isHidden)
+    icon.classList.toggle("bi-eye", isHidden)
+  }
+}

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -8,17 +8,32 @@
         <%= render "devise/shared/error_messages", resource: resource %>
         <%= f.hidden_field :reset_password_token %>
 
-        <div class="mt-3">
+        <div class="mb-3 password-wrapper" data-controller="password-toggle">
           <%= f.label :新しいパスワード, class: "form-label mb-1" %>
           <% if @minimum_password_length %>
             <small class="text-muted">（<%= @minimum_password_length %>文字以上）</small>
           <% end %>
-          <%= f.password_field :password, autofocus: true, class: "form-control" %>
+          <div class="input-group">
+            <%= f.password_field :password, 
+                autofocus: true, 
+                class: "form-control", 
+                data: { "password-toggle-target": "input" } %>
+              <i class="bi bi-eye password-toggle-icon" 
+                  data-password-toggle-target="icon"
+                  data-action="click->password-toggle#toggle"></i>
+          </div>
         </div>
 
-        <div class="field mt-3">
+        <div class="mb-4 password-wrapper">
           <%= f.label :新しいパスワード（確認用）, class: "form-label mb-1" %>
-          <%= f.password_field :password_confirmation, class: "form-control" %>
+          <div class="input-group">
+            <%= f.password_field :password_confirmation,
+                class: "form-control",
+                data: { "password-toggle-target": "input" } %>
+              <i class="bi bi-eye password-toggle-icon" 
+                  data-password-toggle-target="icon"
+                  data-action="click->password-toggle#toggle"></i>
+          </div>
         </div>
 
         <div class="d-grid mb-4">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -17,17 +17,33 @@
           <%= f.email_field :email, class: "form-control", autofocus: true, autocomplete: "email" %>
         </div>
 
-        <div class="mb-3">
+        <div class="mb-3 password-wrapper" data-controller="password-toggle">
           <%= f.label :password, class: "form-label mb-1" %>
           <% if @minimum_password_length %>
             <small class="text-muted">（<%= @minimum_password_length %>文字以上）</small>
           <% end %>
-          <%= f.password_field :password, class: "form-control", autocomplete: "new-password" %>
+          <div class="input-group">
+            <%= f.password_field :password, 
+                class: "form-control", 
+                autocomplete: "new-password", 
+                data: { "password-toggle-target": "input" } %>
+              <i class="bi bi-eye password-toggle-icon" 
+                  data-password-toggle-target="icon"
+                  data-action="click->password-toggle#toggle"></i>
+          </div>
         </div>
 
-        <div class="mb-5">
+        <div class="mb-5 password-wrapper" data-controller="password-toggle">
           <%= f.label :password_confirmation, class: "form-label mb-1" %>
-          <%= f.password_field :password_confirmation, class: "form-control", autocomplete: "new-password" %>
+          <div class="input-group">
+            <%= f.password_field :password_confirmation, 
+                class: "form-control", 
+                autocomplete: "new-password", 
+                data: { "password-toggle-target": "input" } %>
+              <i class="bi bi-eye password-toggle-icon" 
+                  data-password-toggle-target="icon"
+                  data-action="click->password-toggle#toggle"></i>
+          </div>
         </div>
 
         <div class="d-grid mb-4">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -11,9 +11,17 @@
           <%= f.email_field :email, class: "form-control", autofocus: true, autocomplete: "email" %>
         </div>
 
-        <div class="mb-3">
+        <div class="mb-3 password-wrapper" data-controller="password-toggle">
           <%= f.label :password, class: "form-label mb-1" %>
-          <%= f.password_field :password, class: "form-control", autocomplete: "current-password" %>
+          <div class="input-group">
+            <%= f.password_field :password,
+                  class: "form-control",
+                  autocomplete: "current-password",
+                  data: { "password-toggle-target": "input" } %>
+              <i class="bi bi-eye password-toggle-icon" 
+                  data-password-toggle-target="icon"
+                  data-action="click->password-toggle#toggle"></i>
+          </div>
         </div>
 
         <% if devise_mapping.rememberable? %>
@@ -32,7 +40,9 @@
         <div class="mb-3">
           <%= render "devise/shared/links" %>
         </div>
-        <%= link_to "パスワードを忘れた方はこちら", new_user_password_path %>
+        <div>
+          <%= link_to "パスワードを忘れた方はこちら", new_user_password_path, class: "text-navy"%>
+        </div>
       </div>
 
       <div class="text-center">

--- a/app/views/shared/_gacha_status.html.erb
+++ b/app/views/shared/_gacha_status.html.erb
@@ -7,19 +7,21 @@
       request.path != explanation_path && 
       request.path != password_reset_done_path &&
       action_name != "public_result" && %>
-  <div class="d-flex justify-content-between align-items-center my-2 ms-2 me-2">
-    <div id="coin-tooltip-target"
-        class="d-flex align-items-center bg-white border rounded-pill px-2 shadow-sm" 
-        style="min-width: 60px;"
-        title="コインを使ってガチャを引くことができます。コインはカウント保存時に、一貫につき1コイン獲得できます。">
-      <%= image_tag("icons/coin.svg", size: "20x20", class: "me-2") %>
-      <strong class="text-dark"><%= current_user.coin %></strong>
-    </div>
-    <% if controller_name == "gachas" || controller_name == "user_gacha_lists"%>
-      <div class="small">
-        ガチャ数 <%= current_user.user_gacha_lists.count %> 回　
-        収集率 <%= (GachaList.count > 0 ? (current_user.user_gacha_lists.distinct.count(:gacha_list_id).to_f / GachaList.count * 100).floor : 0) %>%
+  <% if current_user %>
+    <div class="d-flex justify-content-between align-items-center my-2 ms-2 me-2">
+      <div id="coin-tooltip-target"
+          class="d-flex align-items-center bg-white border rounded-pill px-2 shadow-sm" 
+          style="min-width: 60px;"
+          title="コインを使ってガチャを引くことができます。コインはカウント保存時に、一貫につき1コイン獲得できます。">
+        <%= image_tag("icons/coin.svg", size: "20x20", class: "me-2") %>
+        <strong class="text-dark"><%= current_user.coin %></strong>
       </div>
-    <% end %>
-  </div>
+      <% if controller_name == "gachas" || controller_name == "user_gacha_lists"%>
+        <div class="small">
+          ガチャ数 <%= current_user.user_gacha_lists.count %> 回　
+          収集率 <%= (GachaList.count > 0 ? (current_user.user_gacha_lists.distinct.count(:gacha_list_id).to_f / GachaList.count * 100).floor : 0) %>%
+        </div>
+      <% end %>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/shared/_guest_user_message.html.erb
+++ b/app/views/shared/_guest_user_message.html.erb
@@ -1,6 +1,7 @@
 <% if current_user&.guest? && 
       request.path != "/users/sign_in" && 
       request.path != "/users/sign_up" && 
+      request.path != "/users/password/new" && 
       request.path != user_registration_path && 
       request.path != explanation_path && 
       request.path != password_reset_done_path &&

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -46,13 +46,12 @@ Rails.application.configure do
   config.action_mailer.smtp_settings = {
     address: 'smtp.gmail.com',
     port: 587,
-    domain: 'localhost', 
+    domain: 'localhost',
     user_name: 'apikey',
-    password: ENV['SENDGRID_API_KEY'],
+    password: ENV.fetch('SENDGRID_API_KEY', nil),
     authentication: 'plain',
     enable_starttls_auto: true
   }
-
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -18,7 +18,6 @@ Rails.application.configure do
 
   config.action_controller.default_url_options = { host: 'https://sushi-counter.com' }
 
-
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
   # config.require_master_key = true
@@ -74,11 +73,10 @@ Rails.application.configure do
     domain: 'sushi-counter.com',
     authentication: :plain,
     user_name: 'apikey',
-    password: ENV['SENDGRID_API_KEY'],
+    password: ENV.fetch('SENDGRID_API_KEY', nil),
     enable_starttls_auto: true
   }
   config.action_mailer.default_url_options = { host: 'sushi-counter.com', protocol: 'https' }
-
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
@@ -111,7 +109,6 @@ Rails.application.configure do
 
   config.hosts << 'www.sushi-counter.com'
   config.hosts << 'sushi-counter.com'
-  
 end
 
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -30,11 +30,13 @@ ja:
   counters:
     reset_notice: カウントをリセットしました
     update_notice: カウントを更新しました
+    update_else_notice: カウントを保存しました
     edit_notice: カウントを編集します
     destroy_notice: 削除しました
   gachas: 
     coin_alert: コインが足りません
     guest_alert: ゲストユーザーはプレイできません
+    public_result_alert: 共有されたガチャ結果が見つかりません
   sushi_items:
     create_notice: 作成しました
     edit_alert: 編集権限がありません

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -12,7 +12,7 @@ job_type :rake, <<~CMD.strip
   cd :path && bundle exec rake :task RAILS_ENV=:environment >> log/cron.log 2>&1
 CMD
 
-every 4.hour do
+every 4.hours do
   rake "guest_user:cleanup"
   command "echo '✅ CRON CHECK: #{Time.zone.now}' >> log/cron.log 2>&1"
 end

--- a/db/migrate/20250725100957_add_public_token_to_user_gacha_lists.rb
+++ b/db/migrate/20250725100957_add_public_token_to_user_gacha_lists.rb
@@ -1,6 +1,8 @@
 class AddPublicTokenToUserGachaLists < ActiveRecord::Migration[7.0]
   def change
-    add_column :user_gacha_lists, :public_token, :string
-    add_index :user_gacha_lists, :public_token, unique: true
+    change_table :user_gacha_lists, bulk: true do |t|
+      t.string :public_token
+      t.index :public_token, unique: true
+    end
   end
 end

--- a/spec/factories/counters.rb
+++ b/spec/factories/counters.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :counter do
-    eaten_at { Date.today }
+    eaten_at { Time.zone.today }
     store_name { "スシロー" }
     user
   end

--- a/spec/factories/gacha_lists.rb
+++ b/spec/factories/gacha_lists.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
 
     after(:build) do |gacha|
       gacha.image.attach(
-        io: File.open(Rails.root.join("spec/fixtures/files/sample.png")),
+        io: Rails.root.join("spec/fixtures/files/sample.png").open,
         filename: "sample.png",
         content_type: "image/png"
       )

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :user do
-    name { "testname"}
+    name { "testname" }
     email { Faker::Internet.unique.email }
     password { "password123" }
   end

--- a/spec/models/sushi_item_spec.rb
+++ b/spec/models/sushi_item_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe SushiItem, type: :model do
     end
 
     it "nameがない場合にバリデーションが機能してinvalidになるか" do
-      sushi_without_name = build(:sushi_item, name:"")
+      sushi_without_name = build(:sushi_item, name: "")
       expect(sushi_without_name).to be_invalid
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,5 +1,3 @@
-
-
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'

--- a/spec/requests/counters_spec.rb
+++ b/spec/requests/counters_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Counters", type: :request do
 
   before do
     sign_in user
-    counter = create(:counter, user: user, store_name: "くら寿司", saved: true)
+    create(:counter, user: user, store_name: "くら寿司", saved: true)
   end
 
   describe "GET /counters/new" do
@@ -20,23 +20,22 @@ RSpec.describe "Counters", type: :request do
     it "index画面に遷移し、保存され、コインが増える" do
       get new_counter_path
       counter = user.counters.order(created_at: :desc).first
-  
+
       sushi_item # ← 作成しておく
-  
+
       # カウント情報を追加（nested attributes）
       counter.sushi_item_counters.create!(sushi_item: sushi_item, count: 5)
-  
-      expect {
+
+      expect do
         patch counter_path(counter), params: {
           counter: {
             store_name: "スシロー",
             update_source: "new"
           }
         }
-      }.to change { user.reload.coin }.by(counter.total_sushi_count)
+      end.to change { user.reload.coin }.by(counter.total_sushi_count)
     end
   end
-
 
   describe "GET /counters" do
     it "保存したcounterが表示される" do
@@ -65,9 +64,9 @@ RSpec.describe "Counters", type: :request do
   describe "DELETE /counters/:id" do
     it "Counterを削除できる" do
       counter = create(:counter, user: user)
-      expect {
+      expect do
         delete counter_path(counter)
-      }.to change(Counter, :count).by(-1)
+      end.to change(Counter, :count).by(-1)
 
       expect(response).to redirect_to(counters_path)
     end

--- a/spec/requests/gachas_spec.rb
+++ b/spec/requests/gachas_spec.rb
@@ -27,9 +27,9 @@ RSpec.describe "Gachas", type: :request do
 
     context "コインが十分にある場合" do
       it "ガチャを引いてコインが減り、リダイレクトされる" do
-        expect {
+        expect do
           post draw_gachas_path, params: { times: 1 }
-        }.to change(UserGachaList, :count).by(1)
+        end.to change(UserGachaList, :count).by(1)
 
         expect(user.reload.coin).to eq(5)
         expect(response).to redirect_to(result_gachas_path)

--- a/spec/requests/health_check_spec.rb
+++ b/spec/requests/health_check_spec.rb
@@ -7,5 +7,4 @@ RSpec.describe "HealthChecks", type: :request do
       expect(response).to have_http_status(:success)
     end
   end
-
 end

--- a/spec/requests/sushi_items_spec.rb
+++ b/spec/requests/sushi_items_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe "SushiItems", type: :request do
   let(:user) { create(:user) }
-  let!(:category) { create(:category) } 
+  let!(:category) { create(:category) }
   let!(:other_category) { create(:category) }
 
   before { sign_in user }
@@ -38,7 +38,7 @@ RSpec.describe "SushiItems", type: :request do
       end
 
       it "画像を追加できる" do
-        file = fixture_file_upload(Rails.root.join('spec', 'fixtures', 'files', 'sample.png'), 'image/png')
+        file = fixture_file_upload(Rails.root.join("spec/fixtures/files/sample.png"), 'image/png')
         patch sushi_item_path(sushi_item), params: {
           sushi_item: { image: file },
           category_id: category.id
@@ -51,7 +51,7 @@ RSpec.describe "SushiItems", type: :request do
       it "画像を削除できる" do
         # 事前に画像を添付しておく
         sushi_item.image.attach(
-          io: File.open(Rails.root.join('spec', 'fixtures', 'files', 'sample.png')),
+          io: Rails.root.join("spec/fixtures/files/sample.png").open,
           filename: 'sample.png',
           content_type: 'image/png'
         )

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,4 +1,3 @@
-
 require 'rails_helper'
 
 RSpec.describe "Users", type: :request do
@@ -44,7 +43,7 @@ RSpec.describe "Users", type: :request do
   describe "POST /users (sign up)" do
     context "正しい情報が送信された場合" do
       it "ユーザー登録に成功しリダイレクトされる" do
-        expect {
+        expect do
           post user_registration_path, params: {
             user: {
               email: "newuser@example.com",
@@ -53,7 +52,7 @@ RSpec.describe "Users", type: :request do
               name: "新規ユーザー"
             }
           }
-        }.to change(User, :count).by(1)
+        end.to change(User, :count).by(1)
 
         expect(response).to redirect_to(root_path)
         follow_redirect!
@@ -63,7 +62,7 @@ RSpec.describe "Users", type: :request do
 
     context "不正な情報が送信された場合（パスワード不一致など）" do
       it "ユーザー登録に失敗しエラーメッセージが表示される" do
-        expect {
+        expect do
           post user_registration_path, params: {
             user: {
               email: "invalid@example.com",
@@ -72,7 +71,7 @@ RSpec.describe "Users", type: :request do
               name: "エラー"
             }
           }
-        }.not_to change(User, :count)
+        end.not_to change(User, :count)
 
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.body).to include("パスワード(確認)とパスワードの入力が一致しません") # 日本語訳に応じて調整

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,51 +44,49 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # This allows you to limit a spec run to individual examples or groups
-  # you care about by tagging them with `:focus` metadata. When nothing
-  # is tagged with `:focus`, all examples get run. RSpec also provides
-  # aliases for `it`, `describe`, and `context` that include `:focus`
-  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  config.filter_run_when_matching :focus
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  # https://rspec.info/features/3-12/rspec-core/configuration/zero-monkey-patching-mode/
-  config.disable_monkey_patching!
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
-  end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+  #   # This allows you to limit a spec run to individual examples or groups
+  #   # you care about by tagging them with `:focus` metadata. When nothing
+  #   # is tagged with `:focus`, all examples get run. RSpec also provides
+  #   # aliases for `it`, `describe`, and `context` that include `:focus`
+  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  #   config.filter_run_when_matching :focus
+  #
+  #   # Allows RSpec to persist some state between runs in order to support
+  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
+  #   # you configure your source control system to ignore this file.
+  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  #
+  #   # Limits the available syntax to the non-monkey patched syntax that is
+  #   # recommended. For more details, see:
+  #   # https://rspec.info/features/3-12/rspec-core/configuration/zero-monkey-patching-mode/
+  #   config.disable_monkey_patching!
+  #
+  #   # Many RSpec users commonly either run the entire suite or an individual
+  #   # file, and it's useful to allow more verbose output when running an
+  #   # individual spec file.
+  #   if config.files_to_run.one?
+  #     # Use the documentation formatter for detailed output,
+  #     # unless a formatter has already been configured
+  #     # (e.g. via a command-line flag).
+  #     config.default_formatter = "doc"
+  #   end
+  #
+  #   # Print the 10 slowest examples and example groups at the
+  #   # end of the spec run, to help surface which specs are running
+  #   # particularly slow.
+  #   config.profile_examples = 10
+  #
+  #   # Run specs in random order to surface order dependencies. If you find an
+  #   # order dependency and want to debug it, you can fix the order by providing
+  #   # the seed, which is printed after each run.
+  #   #     --seed 1234
+  #   config.order = :random
+  #
+  #   # Seed global randomization in this process using the `--seed` CLI option.
+  #   # Setting this allows you to use `--seed` to deterministically reproduce
+  #   # test failures related to randomization by passing the same `--seed` value
+  #   # as the one that triggered the failure.
+  #   Kernel.srand config.seed
 end


### PR DESCRIPTION
## 概要
- パスワード入力フォームで、目のマークをクリックすると表示・非表示を切り替えられる。

## 実施内容
- javascriptで実装
- コントローラーを作成し、クリックしたときのアクションを作成
- 各ビューに適応