### PR TITLE
パスワード非表示機能修正

### DIFF
--- a/app/javascript/controllers/password_toggle_controller.js
+++ b/app/javascript/controllers/password_toggle_controller.js
@@ -1,22 +1,18 @@
 import { Controller } from "@hotwired/stimulus"
 
+// HTML上で data-controller="password-toggle" を付けた要素に対応
 export default class extends Controller {
   static targets = ["input", "icon"]
-  static classes = ["visible", "hidden"]
-
-  connect() {
-    this.hidden = true
-    this.update()
-  }
 
   toggle() {
-    this.hidden = !this.hidden
-    this.update()
-  }
+    const input = this.inputTarget
+    const icon = this.iconTarget
 
-  update() {
-    this.inputTarget.type = this.hidden ? "password" : "text"
-    this.iconTarget.classList.toggle("bi-eye-slash", this.hidden)
-    this.iconTarget.classList.toggle("bi-eye", !this.hidden)
+    const isHidden = input.type === "password"
+    input.type = isHidden ? "text" : "password"
+
+    // アイコン切り替え（Bootstrap Icons想定）
+    icon.classList.toggle("bi-eye-slash", !isHidden)
+    icon.classList.toggle("bi-eye", isHidden)
   }
 }

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -16,6 +16,7 @@
           <div class="input-group">
             <%= f.password_field :password, 
                 autofocus: true, 
+                autocomplete: "off", 
                 class: "form-control", 
                 data: { "password-toggle-target": "input" } %>
               <i class="bi bi-eye password-toggle-icon" 
@@ -29,6 +30,7 @@
           <div class="input-group">
             <%= f.password_field :password_confirmation,
                 class: "form-control",
+                autocomplete: "off", 
                 data: { "password-toggle-target": "input" } %>
               <i class="bi bi-eye password-toggle-icon" 
                   data-password-toggle-target="icon"

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -25,7 +25,7 @@
           <div class="input-group">
             <%= f.password_field :password, 
                 class: "form-control", 
-                autocomplete: "new-password", 
+                autocomplete: "off", 
                 data: { "password-toggle-target": "input" } %>
               <i class="bi bi-eye password-toggle-icon" 
                   data-password-toggle-target="icon"
@@ -38,7 +38,7 @@
           <div class="input-group">
             <%= f.password_field :password_confirmation, 
                 class: "form-control", 
-                autocomplete: "new-password", 
+                autocomplete: "off", 
                 data: { "password-toggle-target": "input" } %>
               <i class="bi bi-eye password-toggle-icon" 
                   data-password-toggle-target="icon"


### PR DESCRIPTION
## 概要
スマホの新規登録画面で非表示にしているのに表示されてしまう

## 実施内容
autocompleteをoffに修正