### PR TITLE
デフォルト画像が設定されていない寿司の画像を削除したときに、画像が削除される

### DIFF
--- a/app/controllers/sushi_items_controller.rb
+++ b/app/controllers/sushi_items_controller.rb
@@ -183,13 +183,17 @@ class SushiItemsController < ApplicationController
       "たい" => "tai.png"
     }[sushi.name]
 
-    return unless default_filename
-
-    path = Rails.root.join("app/assets/images/seeds/#{default_filename}")
-    return unless File.exist?(path)
-
     user_image = sushi.user_sushi_item_images.find_or_initialize_by(user_id: current_user.id)
-    user_image.image.purge if user_image.image.attached?
-    sushi.image.attach(io: File.open(path), filename: default_filename, content_type: "image/png")
+
+    if default_filename
+      path = Rails.root.join("app/assets/images/seeds/#{default_filename}")
+      return unless File.exist?(path)
+
+      user_image.image.purge if user_image.image.attached?
+      sushi.image.attach(io: File.open(path), filename: default_filename, content_type: "image/png")
+
+    else
+      user_image&.image&.purge
+    end
   end
 end


### PR DESCRIPTION
## 概要
デフォルト画像が設定されていない寿司の画像を元に戻したときに、画像が削除されるように実装

## 実施内容
- sushi_items_controllerのreset_default_imageメソッドで、defaultfilenameがない場合user_sushi_item_imageをpurgeするように記述。