### PR TITLE
メールアドレス変更時にパスワード入力_#157

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,8 @@ group :development do
 
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
+
+  gem 'letter_opener_web'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    childprocess (5.1.0)
+      logger (~> 1.5)
     chronic (0.10.2)
     concurrent-ruby (1.3.5)
     crass (1.0.6)
@@ -178,6 +180,17 @@ GEM
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
     language_server-protocol (3.17.0.5)
+    launchy (3.1.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+      logger (~> 1.6)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
+    letter_opener_web (3.0.0)
+      actionmailer (>= 6.1)
+      letter_opener (~> 1.9)
+      railties (>= 6.1)
+      rexml
     lint_roller (1.1.0)
     logger (1.7.0)
     loofah (2.24.1)
@@ -437,6 +450,7 @@ DEPENDENCIES
   jbuilder
   jsbundling-rails
   kaminari
+  letter_opener_web
   meta-tags
   mini_magick (~> 4.12)
   mysql2 (~> 0.5)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,6 +20,13 @@ class UsersController < ApplicationController
 
   def request_email_change
     new_email = params[:user][:new_email]
+    current_password = params[:user][:current_password]
+
+    unless current_user.valid_password?(current_password)
+      flash[:alert] = "パスワードが正しくありません。"
+      redirect_to edit_user_path and return
+    end
+
     current_user.send_email_change_confirmation(new_email)
     redirect_to email_change_done_path, notice: '確認メールを送信しました。'
   end

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -9,6 +9,11 @@
           <%= email_field_tag 'user[new_email]', nil, required: true, class: "form-control" %>
         </div>
 
+        <div class="form-group mt-3">
+          <%= label_tag 'user[current_password]', "パスワード", class: "form-label mb-1" %>
+          <%= password_field_tag 'user[current_password]', nil, required: true, class: "form-control", autocomplete:"new-password" %>
+        </div>
+
         <div class="d-grid mt-4">
           <%= f.submit "確認メールを送信", class: "btn btn-navy" %>
         </div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -42,7 +42,7 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
-  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.delivery_method = :letter_opener_web
   config.action_mailer.smtp_settings = {
     address: 'smtp.sendgrid.net',
     port: 587,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,6 +61,9 @@ Rails.application.routes.draw do
 
   resource :user, only: [:show, :update, :edit] 
 
+  if Rails.env.development?
+    mount LetterOpenerWeb::Engine, at: "/letter_opener"
+  end
 
   
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
## 概要
メールアドレス変更時に、パスワードを入力しないと確認メールが送信されない

## 実施内容
- users/edit(メールアドレス変更申請画面)にパスワード入力フィールド追加
- users_controllerのrequest_email_changeアクションでパスワード認証確認を追加
- lettre opner追加