### PR TITLE
sushi_items_controller#index時にn+1クエリが発生しないように修正

### DIFF
--- a/app/controllers/sushi_items_controller.rb
+++ b/app/controllers/sushi_items_controller.rb
@@ -8,11 +8,24 @@ class SushiItemsController < ApplicationController
 
       if params[:favorites].present?
         @sushi_items = current_user.bookmarked_sushi_items
-            .includes(:sushi_item_counters, :category)
+            .includes(
+              :sushi_item_counters, 
+              :category,
+              :user_sushi_item_images,
+              :bookmarks,
+              image_attachment: :blob
+            )
             .order("id ASC")
       
       else
-        @sushi_items = SushiItem.includes(:sushi_item_counters, :category)
+        @sushi_items = SushiItem
+            .includes(
+              :sushi_item_counters, 
+              :category,
+              :user_sushi_item_images,
+              :bookmarks,
+              image_attachment: :blob
+            )
             .where(category_id: @selected_category&.id)
             .where("created_by_user_id = ? OR created_by_user_id IS NULL", current_user.id)
             .order("id ASC")


### PR DESCRIPTION
## 概要
- `sushi_items_controller#index`で寿司一覧を表示するときにn+1が発生しているため修正
- ActiveStorage関連、sushi_item_counters、bookmarks、user_sushi_item_imagesで発生

## 実施内容
- `includes`の内容に以下を追加
  - bookmarks
  - user_sushi_item_images
  - image_attachment: :blob