### PR TITLE
カウント編集画面でアイテムの更新時のカウント表示不具合修正

### DIFF
--- a/app/controllers/counters_controller.rb
+++ b/app/controllers/counters_controller.rb
@@ -31,7 +31,6 @@ class CountersController < ApplicationController
 
   def edit
     @counter = current_user.counters.find(params[:id])
-
   end
 
   def update

--- a/app/controllers/sushi_items_controller.rb
+++ b/app/controllers/sushi_items_controller.rb
@@ -72,7 +72,12 @@ class SushiItemsController < ApplicationController
 
   def update
     @sushi_item = SushiItem.find_by(id: params[:id])
-    @counter = current_user.counters.order(created_at: :desc).first_or_create!(eaten_at: Time.current)
+
+    @counter = current_counter
+    unless @counter
+      @counter = current_user.counters.order(created_at: :desc).first_or_create!(eaten_at: Time.current)
+      set_current_counter(@counter)
+    end
 
     unless @sushi_item.created_by_user_id == current_user.id || @sushi_item.created_by_user_id.nil?
       redirect_to sushi_items_path, alert: t('sushi_items.update_alert')
@@ -128,6 +133,10 @@ class SushiItemsController < ApplicationController
 
     sushi_counter = @sushi_item.sushi_item_counters.find_or_initialize_by(counter_id: @counter.id)
     sushi_counter.update_count!(params[:direction])
+
+    @sushi_items = @counter.sushi_items
+                          .where(category: @selected_category)
+                          .order(:position)
 
     respond_to do |format|
       format.turbo_stream

--- a/app/views/sushi_items/_category_and_list.html.erb
+++ b/app/views/sushi_items/_category_and_list.html.erb
@@ -1,22 +1,14 @@
-<turbo-frame id="category_nav" data-selected-category-id="<%= @selected_category&.id %>">
-  <%= render "sushi_items/category_nav", categories: categories, selected_category: selected_category %>
+<%= render "sushi_items/category_nav", categories: categories, selected_category: selected_category %>
 
-  <h2 class="mb-1">
-    <% if @counter && @counter.saved? %>
-      <span class="badge bg-warning text-dark mx-1">編集中</span>
-    <% end %>
-  </h3>
+<div class="sushi-grid mb-7">
+  <%= render sushi_items %>
+</div>
 
-  <div class="sushi-grid mb-7">
-    <%= render sushi_items %>
-  </div>
-
-  <div class="plus-nav">
-    <%= link_to new_sushi_item_path(return_category_id: @selected_category&.id),
-        class: "shadow bg-navy text-white rounded-circle d-inline-flex justify-content-center align-items-center",
-        style: "width: 55px; height: 55px;",
-        data: { turbo_frame: "modal_frame" } do %>
-          <i class="bi bi-plus-lg fs-5"></i>
-        <% end %>
-  </div>
-</turbo-frame>
+<div class="plus-nav">
+  <%= link_to new_sushi_item_path(return_category_id: @selected_category&.id),
+      class: "shadow bg-navy text-white rounded-circle d-inline-flex justify-content-center align-items-center",
+      style: "width: 55px; height: 55px;",
+      data: { turbo_frame: "modal_frame" } do %>
+        <i class="bi bi-plus-lg fs-5"></i>
+      <% end %>
+</div>

--- a/app/views/sushi_items/_list.html.erb
+++ b/app/views/sushi_items/_list.html.erb
@@ -1,0 +1,5 @@
+<% cache ['sushi_items_list', selected_category&.id, (sushi_items.maximum(:updated_at) || 0)] do %>
+  <div class="sushi-grid mb-7">
+    <%= render sushi_items %>
+  </div>
+<% end %>

--- a/app/views/sushi_items/index.html.erb
+++ b/app/views/sushi_items/index.html.erb
@@ -1,5 +1,11 @@
 <% content_for :title, "カウンター" %>
 
+<h2 class="mb-1">
+  <% if @counter && @counter.saved? %>
+    <span class="badge bg-warning text-dark mx-1">編集中</span>
+  <% end %>
+</h3>
+
 <turbo-frame id="category_nav" data-selected-category-id="<%= @selected_category&.id %>">
   <%= render partial: "sushi_items/category_and_list", locals: { categories: @categories, selected_category: @selected_category, sushi_items: @sushi_items, counter: @counter } %>
 </turbo-frame>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,9 @@ Rails.application.routes.draw do
       delete :remove_image
     end
     resource :bookmark, only: [:create, :destroy]
+    collection do
+      get :list
+    end
   end
 
   resources :counters, only: [:new, :update, :index, :show, :edit, :destroy] do


### PR DESCRIPTION
## 概要
カウント編集画面でアイテムの更新時、更新アイテムのカウント数が最新のcounterの数になる不具合の修正
## 実施内容
- sushi_item_controllerのupdateアクションで取得する '@counter' の値をcurrent_counterに変更